### PR TITLE
fix unit tests password of test_get_ovf_env_missing_*

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -328,43 +328,11 @@ mod tests {
             </wa:PlatformSettingsSection>
         </Environment>"#;
 
-        let environment: Environment = parse_ovf_env(ovf_body).unwrap();
-
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .username,
-            "myusername"
-        );
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .password,
-            ""
-        );
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .hostname,
-            "myhostname"
-        );
-        assert_eq!(
-            environment
-                .platform_settings_section
-                .platform_settings
-                .preprovisioned_vm,
-            true
-        );
-        assert_eq!(
-            environment
-                .platform_settings_section
-                .platform_settings
-                .preprovisioned_vm_type,
-            "None"
-        );
+        assert!(parse_ovf_env(ovf_body)
+            .err()
+            .unwrap()
+            .downcast::<std::io::Error>()
+            .is_err());
     }
 
     #[test]
@@ -398,42 +366,10 @@ mod tests {
             </wa:PlatformSettingsSection>
         </Environment>"#;
 
-        let environment: Environment = parse_ovf_env(ovf_body).unwrap();
-
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .username,
-            "myusername"
-        );
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .password,
-            ""
-        );
-        assert_eq!(
-            environment
-                .provisioning_section
-                .linux_prov_conf_set
-                .hostname,
-            "myhostname"
-        );
-        assert_eq!(
-            environment
-                .platform_settings_section
-                .platform_settings
-                .preprovisioned_vm,
-            false
-        );
-        assert_eq!(
-            environment
-                .platform_settings_section
-                .platform_settings
-                .preprovisioned_vm_type,
-            "None"
-        );
+        assert!(parse_ovf_env(ovf_body)
+            .err()
+            .unwrap()
+            .downcast::<std::io::Error>()
+            .is_err());
     }
 }


### PR DESCRIPTION
Fix failures in unit tests `test_get_ovf_env_missing_password`, `test_get_ovf_env_missing_three`, by checking for errors instead of actual values.
As `parse_ovf_env` is expected to return errors if the password is empty, it is not necessary to check other returned fields.

Fixes https://github.com/Azure/azure-provisioning-agent/issues/30

## Testing done

`cargo test` passed