### PR TITLE
Changing image_script to use new image definition V1

### DIFF
--- a/demo/image_creation.sh
+++ b/demo/image_creation.sh
@@ -106,7 +106,6 @@ echo "Capturing OsDisk snapshot of vm $vm with image $image"
 echo "*********************************************************************"
 target_disk=$(az disk show --ids $(az vm show -g $rg -n $vm | jq .storageProfile.osDisk.managedDisk.id -r) | jq .name -r)
 az snapshot create -g $rg -n $vm-snapshot --source $target_disk
-az snapshot show -g $rg -n $vm-snapshot
 
 version=$(date '+%Y.%m%d.%H%M%S')
 gallery=testgalleryagent

--- a/demo/image_creation.sh
+++ b/demo/image_creation.sh
@@ -109,7 +109,7 @@ az vm deallocate -g $rg -n $vm
 while [ "$(az vm get-instance-view -g $rg -n $vm --query 'instanceView.statuses[?code==`PowerState/deallocated`].displayStatus' -o tsv)" != "VM deallocated" ]
 do
     echo "Waiting for VM to be deallocated..."
-    sleep 10
+    sleep 30
 done
 az vm generalize -g $rg -n $vm
 echo "Done"
@@ -118,7 +118,7 @@ version=$(date '+%Y.%m%d.%H%M%S')
 gallery=testgalleryagent
 definition=testgallery-gen1
 gallery_rg=temp-rg-rust-agent-testing
-subscription_id=$(az vm show -g $rg -n $vm | jq -r '.subscriptionId')
+subscription_id=$(az vm show -g $rg -n $vm | grep -oPm 1 '/subscriptions/\K[^/]*')
 echo "*********************************************************************"
 echo "Publishing image version $version to $gallery/$definition"
 echo "*********************************************************************"

--- a/demo/image_creation.sh
+++ b/demo/image_creation.sh
@@ -112,7 +112,6 @@ version=$(date '+%Y.%m%d.%H%M%S')
 gallery=testgalleryagent
 definition=testgallery-gen1
 gallery_rg=temp-rg-rust-agent-testing
-subscription_id=$(az vm show -g $rg -n $vm | jq -r '.id')
 snapshot_id=$(az snapshot show -n $vm-snapshot -g $rg --query id --output tsv)
 echo "*********************************************************************"
 echo "Publishing image version $version to $gallery/$definition"

--- a/demo/image_creation.sh
+++ b/demo/image_creation.sh
@@ -109,9 +109,8 @@ az vm deallocate -g $rg -n $vm
 while [ "$(az vm get-instance-view -g $rg -n $vm --query 'instanceView.statuses[?code==`PowerState/deallocated`].displayStatus' -o tsv)" != "VM deallocated" ]
 do
     echo "Waiting for VM to be deallocated..."
-    sleep 30
+    sleep 10
 done
-    sleep 15
 az vm generalize -g $rg -n $vm
 echo "Done"
 
@@ -119,11 +118,11 @@ version=$(date '+%Y.%m%d.%H%M%S')
 gallery=testgalleryagent
 definition=testgallery-gen1
 gallery_rg=temp-rg-rust-agent-testing
-subscription_id=$(az vm show -g $rg -n $vm | jq .subscriptionId -r)
+subscription_id=$(az vm show -g $rg -n $vm | jq -r '.subscriptionId')
 echo "*********************************************************************"
 echo "Publishing image version $version to $gallery/$definition"
 echo "*********************************************************************"
-az sig image-version create -g $gallery_rg --gallery-name $gallery --gallery-image-definition $definition --gallery-image-version $version --target-regions "eastus" --replica-count 1 --virtual-machine /subscriptions/0a2c89a7-a44e-4cd0-b6ec-868432ad1d13/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/$vm
+az sig image-version create -g $gallery_rg --gallery-name $gallery --gallery-image-definition $definition --gallery-image-version $version --target-regions "eastus" --replica-count 1 --virtual-machine /subscriptions/$subscription_id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/$vm
 if [[ $? -eq 0 ]]
 then
     echo "Image publishing finished"


### PR DESCRIPTION
Updating image_creation script to use new testgalleryimage (a gen1 image) to avoid issues with TrustedLaunch and converting the image to SIG directly rather than using a managed image. 
