### PR TITLE
README: Don't recommend curl | sh to install Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,7 @@ Azure-init has very few requirements on its environment, so it may run in a very
 
 ## Installing Rust
 
-Rust can be installed via the command line using the following command: 
-`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`, or with other options found here:
-https://www.rust-lang.org/tools/install. Following this installation process will also allow for the 
-use of Cargo, which is Rust's compiler and dependency manager. More on the usage of cargo can be found in the building section.
-
-## Pulling Source Code
-
-This source code can accessed by cloning the repository to your machine with the command:
-`git clone git@github.com:Azure/azure-init.git`
+To install Rust see here: https://www.rust-lang.org/tools/install.
 
 ## Building the Project
 


### PR DESCRIPTION
Using `curl | sh ` is questionable from a security POV and not recommended in several circles already.

Let's not do it ourselves, let's link to the installation page, they can (and do) recommend `curl | sh` anyways.

What do you think?

Below is the commit msg:

---

While we are there, let's remove how to clone the repo. That should be clear on Github already.

Signed-off-by: Rodrigo Campos <rodrigoca@microsoft.com>