### PR TITLE
Bump reqwest to the latest version and drop rustfmt

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 description = "A common library for provisioning Linux VMs on Azure."
 
 [dependencies]
-reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "json"] }
+reqwest = { version = "0.11.24", default-features = false, features = ["blocking", "json"] }
 serde = {version = "1.0.163", features = ["derive"]}
 serde_xml = "0.9.1"
 serde_derive = "1.0"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -16,7 +16,6 @@ tokio = { version = "1", features = ["full"] }
 serde-xml-rs = "0.6.0"
 xml-rs = "0.8.13"
 serde_json = "1.0.96"
-rustfmt = "0.10.0"
 nix = "0.26.2"
 libc = "0.2.146"
 


### PR DESCRIPTION
## How to use

Ensure formatting still works as this drops the rustfmt dependency.

## Testing done

Built the project, ran all the tests, ensured `make fmt` still worked as expected by editing a Rust file:
```
❯ make fmt

**********************************
* Formatting
**********************************

Diff in /home/jcline/devel/github.com/Azure/azure-init/libazureinit/src/distro.rs at line 27:
     ) -> Result<i32, String> {
         match self {
             Distributions::Debian | Distributions::Ubuntu => {
-                let mut home_path = "/home/".to_string(); home_path.push_str(username);
+                let mut home_path = "/home/".to_string();
+                home_path.push_str(username);
 
                 match Command::new("useradd")
                     .arg(username)
make: *** [Makefile:26: fmt] Error 1
```

Together these commits address #42 so (at the time of this PR) cargo-audit should be happy.