### PR TITLE
tests: use the private key path when calling ssh-keygen

### DIFF
--- a/tests/functional_tests.sh
+++ b/tests/functional_tests.sh
@@ -25,7 +25,7 @@ if [ -z "${SUBSCRIPTION_ID}" ] ; then
 fi
 
 if [ ! -f "$PATH_TO_PUBLIC_SSH_KEY" ]; then
-    ssh-keygen -t rsa -b 4096 -f $PATH_TO_PUBLIC_SSH_KEY -N ""
+    ssh-keygen -t rsa -b 4096 -f "$PATH_TO_PRIVATE_SSH_KEY" -N ""
     echo "SSH key created."
 else
     echo "SSH key already exists."


### PR DESCRIPTION
In the functional tests, it'll generate an SSH key if you don't already have one (by default `~/.ssh/id_rsa`). However, it passes the path to the public key file name rather than the private key file name so it'll generate `~/.ssh/id_rsa.pub` and `~/.ssh/id_rsa.pub.pub`.

This causes the tests to fail later since it references `~/.ssh/id_rsa`.

## How to use

Run the functional tests with `make e2e-test` and no `~/.ssh/id_rsa.pub` file. Alternatively, set the `$PATH_TO_{PRIVATE,PUBLIC}_SSH_KEY` environment variables to point to files that don't exist.

## Testing done

Ran the end-to-end tests and had it generate a default keypair for me.
