### PR TITLE
github: include the instructions as comments in the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,24 +9,32 @@ assignees: ''
 
 ## Description
 
-__[ 1 paragraph concisely describing the bug ]__
+<!-- [ 1 paragraph concisely describing the bug ] -->
 
 ## Impact
 
-__[ 1 sentence detailing the impact this bug is creating for you ]__
+<!-- [ 1 sentence detailing the impact this bug is creating for you ] -->
 
 ## Environment and steps to reproduce
 
-1. **Set-up**: __[ describe the environment the agent was running in when encountering the bug; image/distro, instance type, etc. ]__
-2. **Action(s)**: __[ sequence of actions that led to triggering the bug so maintainers can reproduce it; see example below ]__
-  a. __[ ... initiated VM provisioning via the command line ... ]__
-  b. __[ ... provisioning started ... ]__
-3. **Error**: __[describe the error that was triggered]__
+<!-- [ describe the environment the agent was running in when encountering the bug; image/distro, instance type, etc. ] -->
+1. **Set-up**: 
+
+<!-- [ sequence of actions that led to triggering the bug so maintainers can reproduce it; see example below ] -->
+2. **Action(s)**:
+    <!-- [ ... initiated VM provisioning via the command line ... ] -->
+    a. 
+
+    <!-- [ ... provisioning started ... ] -->
+    b.
+
+<!-- [describe the error that was triggered] -->
+3. **Error**:
 
 ## Expected behavior
 
-__[ describe what you expected to happen at 4. above but instead got an error ]__
+<!-- [ describe what you expected to happen at 4. above but instead got an error ] -->
 
 ## Additional information
 
-__[ Please add any information like serial console logs etc. here ]__
+<!-- [ Please add any information like serial console logs etc. here ] -->

--- a/.github/ISSUE_TEMPLATE/enhancement_or_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_or_feature_request.md
@@ -9,20 +9,20 @@ assignees: ''
 
 ## Current situation
 
-__[ Please describe the current situation you would like to have improved ]__
+<!-- [ Please describe the current situation you would like to have improved ] -->
 
 ## Impact
 
-__[ Please describe the impact the lack of the feature requested is creating ]__
+<!-- [ Please describe the impact the lack of the feature requested is creating ] -->
 
 ## Ideal future situation
 
-__[ Please describe the future situation after the improvement was implemented ]__
+<!-- [ Please describe the future situation after the improvement was implemented ] -->
 
 ## **Implementation options
 
-__[ Optional: please provide one or more options for implementing the feature requested ]__
+<!-- [ Optional: please provide one or more options for implementing the feature requested ] -->
 
 ## Additional information
 
-__[ Please add any information that does not fit into any of the above sections here ]__
+<!-- [ Please add any information that does not fit into any of the above sections here ] -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
-__[ Describe the change in 1 - 3 paragraphs ]__
+<!-- [ Describe the change in 1 - 3 paragraphs ] -->
 
 ## How to use
 
-__[ Describe what reviewers need to do in order to validate this PR ]__
+<!-- [ Describe what reviewers need to do in order to validate this PR ] -->
 
 ## Testing done
 
-__[ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ]__
+<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->


### PR DESCRIPTION
Use Markdown comments for the instructions in the PR and issues templates. This way you don't need to remove the instructions as you fill out the form, but they aren't rendered in the resulting issue/PR.

## How to use

Create issues and PRs without needing to delete the instructions as you go.

## Testing done

Examined the output in the VSCode markdown preview window to see the comments not get rendered. This is also the [documented syntax](https://github.github.com/gfm/#html-comment).
