### PR TITLE
tests: Only call az login if there's no access token available

### DIFF
--- a/tests/functional_tests.sh
+++ b/tests/functional_tests.sh
@@ -32,11 +32,12 @@ else
 fi
 
 # Log into Azure (this will open a browser window prompting you to log in)
-echo "Logging you into Azure"
-az login
-
-# Ensure Azure is logged in
-az account get-access-token -o none
+if az account get-access-token -o none; then
+    echo "Using existing Azure account"
+else
+    echo "Logging you into Azure"
+    az login
+fi
 
 # Set the subscription you want to use
 az account set --subscription $SUBSCRIPTION_ID


### PR DESCRIPTION
This changes the functional test script to test if the user is already logged in to Azure so that it doesn't unconditionally stop and prompt the user to log in.

## How to use

Log out via `az logout`, run the script, log back in, and then run the script again.

## Testing done
```
az logout
make e2e-test
make e2e-test
```