### PR TITLE
tests: make functional_tests.sh configurable

### DIFF
--- a/tests/functional_tests.sh
+++ b/tests/functional_tests.sh
@@ -4,15 +4,15 @@
 
 SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-}"
 EPOCH=$(date +%s)
-RG=cade-test-azprovagent-$EPOCH
-LOCATION=eastus
+RG="${RG:-e2etest-azinit-$EPOCH}"
+LOCATION="${LOCATION:-eastus}"
 PATH_TO_PUBLIC_SSH_KEY="$HOME/.ssh/id_rsa.pub"
 PATH_TO_PRIVATE_SSH_KEY="$HOME/.ssh/id_rsa"
-VM_NAME="AzProvAgentFunctionalTest"
-VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
-VM_SIZE="Standard_D2lds_v5"
-VM_ADMIN_USERNAME="azureuser"
-AZURE_SSH_KEY_NAME="azure-ssh-key"
+VM_NAME="${VM_NAME:-AzInitFunctionalTest}"
+VM_IMAGE="${VM_IMAGE:-Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest}"
+VM_SIZE="${VM_SIZE:-Standard_D2lds_v5}"
+VM_ADMIN_USERNAME="${VM_ADMIN_USERNAME:-azureuser}"
+AZURE_SSH_KEY_NAME="${AZURE_SSH_KEY_NAME:-azure-ssh-key}"
 VM_NAME_WITH_TIMESTAMP=$VM_NAME-$EPOCH
 
 set -e


### PR DESCRIPTION
To be able to run `functional_tests.sh` with different parameters, make it configurable by environment variables, like `RG`, `LOCATION`, `VM_SIZE`.

For example, it is now possible to simply run like below, without having to manually update variables in the script:

```
RG="my-test-azinit" LOCATION="germanywestcentral" VM_SIZE="Standard_DS3_v2" make e2e-test
```

Also update the default RG name to `e2etest-azinit`, VM_NAME to `AzInitFunctionalTest`.

## Testing done

Tested in Azure.