### PR TITLE
Set a user-agent and timeout to the HTTP client

### DIFF
--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -39,10 +39,10 @@ pub struct RoleInstance {
     instance_id: String,
 }
 
-pub async fn get_goalstate() -> Result<Goalstate, Box<dyn std::error::Error>> {
+pub async fn get_goalstate(
+    client: &Client,
+) -> Result<Goalstate, Box<dyn std::error::Error>> {
     let url = "http://168.63.129.16/machine/?comp=goalstate";
-
-    let client = Client::new();
 
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
@@ -64,11 +64,10 @@ pub async fn get_goalstate() -> Result<Goalstate, Box<dyn std::error::Error>> {
 }
 
 pub async fn report_health(
+    client: &Client,
     goalstate: Goalstate,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let url = "http://168.63.129.16/machine/?comp=health";
-
-    let client = Client::new();
 
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -18,9 +18,10 @@ pub struct PublicKeys {
     pub path: String,
 }
 
-pub async fn query_imds() -> Result<String, Box<dyn std::error::Error>> {
+pub async fn query_imds(
+    client: &Client,
+) -> Result<String, Box<dyn std::error::Error>> {
     let url = "http://169.254.169.254/metadata/instance?api-version=2021-02-01";
-    let client = Client::new();
     let mut headers = HeaderMap::new();
 
     headers.insert("Metadata", HeaderValue::from_static("true"));

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -6,3 +6,6 @@ pub mod goalstate;
 pub mod imds;
 pub mod media;
 pub mod user;
+
+// Re-export as the Client is used in our API.
+pub use reqwest;


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->

There's two commits in this series, the first adjusts the error handling used in the `azure-init` binary to make clearer to read through. The second adjusts the `libazureinit` APIs that make use of the `reqwest::Client` to accept it as an argument. This allows the caller to control the configuration. Finally, the client is configured in `azure-init` to have a user-agent along with a timeout.

## How to use

<!-- [ Describe what reviewers need to do in order to validate this PR ] -->

Beyond building and running the existing tests, there's not yet tests to assert this actually works. The functional test looks to replicate the `azure-init` binary, so I think it would be interesting to have the test script copy over the actual binary and then make make some assertions about the queries it issues to the metadata service. I assume there's a way to see the requests a guest issues, but need to read up on that.

## Testing done

<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->

I compiled it and ran the functional test, but that doesn't make any assertions about the change here.
