### PR TITLE
Use safe nix interface to retrieve user and group id

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -19,6 +19,9 @@ serde_json = "1.0.96"
 nix = "0.26.2"
 libc = "0.2.146"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lib]
 name = "libazureinit"
 path = "src/lib.rs"

--- a/libazureinit/src/user.rs
+++ b/libazureinit/src/user.rs
@@ -57,18 +57,9 @@ pub async fn create_ssh_directory(
 
     create_dir(file_path.clone())?;
 
-    let uid_username = CString::new(username).unwrap();
-    let uid_passwd = unsafe { libc::getpwnam(uid_username.as_ptr()) };
-    let uid = unsafe { (*uid_passwd).pw_uid };
-    let new_uid = Uid::from_raw(uid);
-
-    let gid_groupname = CString::new(username).unwrap();
-    let gid_group = unsafe { libc::getgrnam(gid_groupname.as_ptr()) };
-    let gid = unsafe { (*gid_group).gr_gid };
-    let new_gid = Gid::from_raw(gid);
-
-    let _set_ownership =
-        nix::unistd::chown(file_path.as_str(), Some(new_uid), Some(new_gid));
+    let user = nix::unistd::User::from_name(username)?.unwrap();
+    nix::unistd::chown(file_path.as_str(), Some(user.uid), Some(user.gid))
+        .unwrap();
 
     let metadata = fs::metadata(&file_path).unwrap();
     let permissions = metadata.permissions();
@@ -77,4 +68,24 @@ pub async fn create_ssh_directory(
     fs::set_permissions(&file_path, new_permissions).unwrap();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::create_ssh_directory;
+
+    #[tokio::test]
+    #[should_panic]
+    async fn user_does_not_exist() {
+        let test_dir = tempfile::tempdir().unwrap();
+        let dir_path = test_dir.path();
+
+        create_ssh_directory(
+            "i_sure_hope_this_user_doesnt_exist",
+            &dir_path.as_os_str().to_str().unwrap().to_string(),
+        )
+        .await
+        .unwrap();
+    }
 }


### PR DESCRIPTION
Using libc APIs directly is difficult and should be avoided if possible. In this case, the manual for getpwnam(3) and getgrnam(3) indicate they return NULL if the entry is not found or an error occurs. Since the return value isn't being checked for NULL here, a null pointer dereference can occur here.

Fortunately, the nix crate provides a wrapper for retrieving user details from a username.

I've added some calls to unwrap() which I'll remove once more error handling is in place.
