### PR TITLE
Disable provisioning with password

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 description = "A reference implementation for provisioning Linux VMs on Azure."
 
 [dependencies]
+exitcode = "1.1.2"
 tokio = { version = "1", features = ["full"] }
 
 [dependencies.libazureinit]

--- a/libazureinit/src/distro.rs
+++ b/libazureinit/src/distro.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::io::Write;
 use std::process::Command;
-use std::process::Stdio;
 
 pub trait Distribution {
     fn create_user(
@@ -60,32 +58,11 @@ impl Distribution for Distributions {
                         Err(err) => return Err(err.to_string()),
                     };
                 } else {
-                    let input = format!("{}:{}", username, password);
-
-                    let mut output = Command::new("chpasswd")
-                        .stdin(Stdio::piped())
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::inherit())
-                        .spawn()
-                        .expect("Failed to run chpasswd.");
-
-                    let mut stdin =
-                        output.stdin.as_ref().ok_or("Failed to open stdin")?;
-
-                    stdin.write_all(input.as_bytes()).map_err(|error| {
-                        format!("Failed to write to stdin: {}", error)
-                    })?;
-
-                    let status = output.wait().map_err(|error| {
-                        format!("Failed to wait for stdin command: {}", error)
-                    })?;
-
-                    if !status.success() {
-                        return Err(format!(
-                            "Chpasswd command failed with exit code {}",
-                            status.code().unwrap_or(-1)
-                        ));
-                    }
+                    // creating user with a non-empty password is not allowed.
+                    return Err(
+                        "Failed to create user with non-empty password"
+                            .to_string(),
+                    );
                 }
 
                 Ok(0)

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -80,7 +80,7 @@ pub fn get_hostname(
     Ok(hostname)
 }
 
-pub fn get_provision_with_password(
+pub fn is_password_authentication_disabled(
     imds_body: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let data: Value = serde_json::from_str(imds_body)
@@ -101,7 +101,8 @@ pub fn get_provision_with_password(
 #[cfg(test)]
 mod tests {
     use super::{
-        get_hostname, get_provision_with_password, get_ssh_keys, get_username,
+        get_hostname, get_ssh_keys, get_username,
+        is_password_authentication_disabled,
     };
 
     #[test]
@@ -210,8 +211,9 @@ mod tests {
         }"#
         .to_string();
 
-        let provision_with_password = get_provision_with_password(&file_body)
-            .expect("Failed to interpret disablePasswordAuthentication.");
+        let provision_with_password =
+            is_password_authentication_disabled(&file_body)
+                .expect("Failed to interpret disablePasswordAuthentication.");
 
         assert_eq!(provision_with_password, true);
     }

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -215,32 +215,4 @@ mod tests {
 
         assert_eq!(provision_with_password, true);
     }
-
-    #[test]
-    fn test_provision_with_password_false() {
-        let file_body = r#"
-        {
-            "compute": {
-              "azEnvironment": "cloud_env",
-              "customData": "",
-              "evictionPolicy": "",
-              "isHostCompatibilityLayerVm": "false",
-              "licenseType": "",
-              "location": "eastus",
-              "name": "AzTux-MinProvAgent-Test-0001",
-              "offer": "0001-com-ubuntu-server-focal",
-              "osProfile": {
-                "adminUsername": "MinProvAgentUser",
-                "computerName": "AzTux-MinProvAgent-Test-0001",
-                "disablePasswordAuthentication": "false"
-              }
-            }
-        }"#
-        .to_string();
-
-        let provision_with_password = get_provision_with_password(&file_body)
-            .expect("Failed to interpret disablePasswordAuthentication.");
-
-        assert_eq!(provision_with_password, false);
-    }
 }

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -5,9 +5,7 @@ use std::fs;
 use std::fs::create_dir_all;
 use std::fs::File;
 use std::io::Read;
-use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
 
 use serde::Deserialize;
 use serde_xml_rs::from_str;
@@ -66,28 +64,6 @@ fn default_preprov_type() -> String {
     "None".to_owned()
 }
 
-pub fn mount_media() {
-    let _mount_media = Command::new("mount")
-        .arg("-o")
-        .arg("ro")
-        .arg("/dev/sr0")
-        .arg("/run/azure-init/tmp/")
-        .status()
-        .expect("Failed to execute mount command.");
-}
-
-pub fn remove_media() {
-    let _unmount_media = Command::new("umount")
-        .arg("/run/azure-init/tmp/")
-        .status()
-        .expect("Failed to execute unmount command.");
-
-    let _eject_media = Command::new("eject")
-        .arg("/dev/sr0")
-        .status()
-        .expect("Failed to execute eject command.");
-}
-
 pub fn make_temp_directory() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "/run/azure-init/tmp/";
 
@@ -127,25 +103,6 @@ pub fn parse_ovf_env(
     }
 
     Ok(environment)
-}
-
-pub fn allow_password_authentication() -> Result<(), Box<dyn std::error::Error>>
-{
-    let file_path = "/etc/ssh/sshd_config.d/40-azure-init.conf";
-    let password_authentication = "PasswordAuthentication yes";
-
-    let mut file =
-        File::create(file_path).expect("Unable to create sshd_config file.");
-    file.write_all(password_authentication.as_bytes())
-        .expect("Unable to write to sshd_config file.");
-
-    let _restart_ssh = Command::new("systemctl")
-        .arg("restart")
-        .arg("ssh")
-        .status()
-        .expect("Failed to execute restart ssh command.");
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,12 +58,12 @@ async fn main() {
     let query_result = imds::query_imds(&client).await;
     let imds_body = match query_result {
         Ok(imds_body) => imds_body,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 
     let username = match get_username(imds_body.clone()) {
         Ok(res) => res,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 
     let mut file_path = "/home/".to_string();
@@ -79,7 +79,7 @@ async fn main() {
     let get_ssh_key_result = imds::get_ssh_keys(imds_body.clone());
     let keys = match get_ssh_key_result {
         Ok(keys) => keys,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 
     file_path.push_str("/.ssh");
@@ -89,7 +89,7 @@ async fn main() {
     let get_hostname_result = imds::get_hostname(imds_body.clone());
     let hostname = match get_hostname_result {
         Ok(hostname) => hostname,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 
     Distributions::from("ubuntu")
@@ -99,13 +99,13 @@ async fn main() {
     let get_goalstate_result = goalstate::get_goalstate(&client).await;
     let vm_goalstate = match get_goalstate_result {
         Ok(vm_goalstate) => vm_goalstate,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 
     let report_health_result =
         goalstate::report_health(&client, vm_goalstate).await;
     match report_health_result {
         Ok(report_health) => report_health,
-        Err(_err) => return,
+        Err(_err) => std::process::exit(exitcode::CONFIG),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 fn get_username(
     imds_body: String,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    if imds::get_provision_with_password(&imds_body).map_err(|_| {
+    if imds::is_password_authentication_disabled(&imds_body).map_err(|_| {
         "Failed to get disable password authentication".to_string()
     })? {
         // password authentication is disabled

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -68,18 +68,6 @@ async fn main() {
     println!("User {} was successfully created", username.as_str());
 
     println!();
-    println!(
-        "Attempting to create user {} with password",
-        username.as_str()
-    );
-
-    Distributions::from("ubuntu")
-        .create_user("test_user_2", "azureProvisioningAgentPassword")
-        .expect("Failed to create user");
-
-    println!("User {} was successfully created", username.as_str());
-
-    println!();
     println!("Attempting to create user's SSH directory");
 
     let _create_directory =


### PR DESCRIPTION
Password authentication by itself not as secure as ssh key. For better security, we should disable password authentication. So if user enabled password authentication in Azure, azure-init now simply fails to provision.

Clean up unnecessary functions in libazureinit, like `mount_media`, `unmount_media`, `allow_password_authentication`.

Fixes https://github.com/Azure/azure-init/issues/52.

## Testing done

Manual test is done.