### PR TITLE
Add errors to the library and remove all unwrap()/expect() calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "A reference implementation for provisioning Linux VMs on Azure."
 
 [dependencies]
 exitcode = "1.1.2"
+anyhow = "1.0.81"
 tokio = { version = "1", features = ["full"] }
 
 [dependencies.libazureinit]

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.11.24", default-features = false, features = ["blocking
 serde = {version = "1.0.163", features = ["derive"]}
 serde_xml = "0.9.1"
 serde_derive = "1.0"
+thiserror = "1.0.58"
 tokio = { version = "1", features = ["full"] }
 serde-xml-rs = "0.6.0"
 xml-rs = "0.8.13"

--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Unable to deserialize or serialize JSON data")]
+    Json(#[from] serde_json::Error),
+    #[error("Unable to deserialize or serialize XML data")]
+    Xml(#[from] serde_xml_rs::Error),
+    #[error("HTTP client error ocurred")]
+    Http(#[from] reqwest::Error),
+    #[error("An I/O error occurred")]
+    Io(#[from] std::io::Error),
+    #[error("HTTP request did not succeed (HTTP {status} from {endpoint})")]
+    HttpStatus {
+        endpoint: String,
+        status: reqwest::StatusCode,
+    },
+    #[error("executing {command} failed: {status}")]
+    SubprocessFailed {
+        command: String,
+        status: std::process::ExitStatus,
+    },
+    #[error("failed to construct a C-style string")]
+    NulError(#[from] std::ffi::NulError),
+    #[error("nix call failed")]
+    Nix(#[from] nix::Error),
+    #[error("The user {user} does not exist")]
+    UserMissing { user: String },
+    #[error("Provisioning a user with a non-empty password is not supported")]
+    NonEmptyPassword,
+}

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 pub mod distro;
+pub mod error;
 pub mod goalstate;
 pub mod imds;
 pub mod media;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::process::ExitCode;
+
+use anyhow::Context;
+
 use libazureinit::distro::{Distribution, Distributions};
 use libazureinit::{
+    error::Error as LibError,
     goalstate, imds, media,
     reqwest::{header, Client},
     user,
@@ -10,30 +15,14 @@ use libazureinit::{
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn get_username(
-    imds_body: String,
-) -> Result<String, Box<dyn std::error::Error>> {
-    if imds::is_password_authentication_disabled(&imds_body).map_err(|_| {
-        "Failed to get disable password authentication".to_string()
-    })? {
+fn get_username(imds_body: String) -> Result<String, LibError> {
+    if imds::is_password_authentication_disabled(&imds_body)? {
         // password authentication is disabled
-        match imds::get_username(imds_body.clone()) {
-            Ok(username) => Ok(username),
-            Err(_err) => Err("Failed to get username".into()),
-        }
+        imds::get_username(imds_body.clone())
     } else {
         // password authentication is enabled
-        let ovf_body = media::read_ovf_env_to_string().unwrap();
-        let environment = media::parse_ovf_env(ovf_body.as_str()).unwrap();
-
-        if !environment
-            .provisioning_section
-            .linux_prov_conf_set
-            .password
-            .is_empty()
-        {
-            return Err("password is non-empty".into());
-        }
+        let ovf_body = media::read_ovf_env_to_string()?;
+        let environment = media::parse_ovf_env(ovf_body.as_str())?;
 
         Ok(environment
             .provisioning_section
@@ -43,28 +32,38 @@ fn get_username(
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
+    match provision().await {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{:?}", e);
+            let config: u8 = exitcode::CONFIG
+                .try_into()
+                .expect("Error code must be less than 256");
+            match e.root_cause().downcast_ref::<LibError>() {
+                Some(LibError::UserMissing { user: _ }) => {
+                    ExitCode::from(config)
+                }
+                Some(LibError::NonEmptyPassword) => ExitCode::from(config),
+                Some(_) | None => ExitCode::FAILURE,
+            }
+        }
+    }
+}
+
+async fn provision() -> Result<(), anyhow::Error> {
     let mut default_headers = header::HeaderMap::new();
     let user_agent = header::HeaderValue::from_str(
         format!("azure-init v{VERSION}").as_str(),
-    )
-    .unwrap();
+    )?;
     default_headers.insert(header::USER_AGENT, user_agent);
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .default_headers(default_headers)
-        .build()
-        .unwrap();
-    let query_result = imds::query_imds(&client).await;
-    let imds_body = match query_result {
-        Ok(imds_body) => imds_body,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
-
-    let username = match get_username(imds_body.clone()) {
-        Ok(res) => res,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
+        .build()?;
+    let imds_body = imds::query_imds(&client).await?;
+    let username = get_username(imds_body.clone())
+        .with_context(|| "Failed to retrieve the admin username.")?;
 
     let mut file_path = "/home/".to_string();
     file_path.push_str(username.as_str());
@@ -72,40 +71,34 @@ async fn main() {
     // always pass an empty password
     Distributions::from("ubuntu")
         .create_user(username.as_str(), "")
-        .expect("Failed to create user");
-    let _create_directory =
-        user::create_ssh_directory(username.as_str(), &file_path).await;
+        .with_context(|| format!("Unabled to create user '{username}'"))?;
 
-    let get_ssh_key_result = imds::get_ssh_keys(imds_body.clone());
-    let keys = match get_ssh_key_result {
-        Ok(keys) => keys,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
+    user::create_ssh_directory(username.as_str(), &file_path)
+        .await
+        .with_context(|| "Failed to create ssh directory.")?;
+
+    let keys = imds::get_ssh_keys(imds_body.clone())
+        .with_context(|| "Failed to get ssh public keys.")?;
 
     file_path.push_str("/.ssh");
 
-    user::set_ssh_keys(keys, username.to_string(), file_path.clone()).await;
+    user::set_ssh_keys(keys, username.to_string(), file_path.clone())
+        .await
+        .with_context(|| "Failed to write ssh public keys.")?;
 
-    let get_hostname_result = imds::get_hostname(imds_body.clone());
-    let hostname = match get_hostname_result {
-        Ok(hostname) => hostname,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
+    let hostname = imds::get_hostname(imds_body.clone())
+        .with_context(|| "Failed to get the configured hostname")?;
 
     Distributions::from("ubuntu")
         .set_hostname(hostname.as_str())
-        .expect("Failed to set hostname");
+        .with_context(|| "Failed to set hostname.")?;
 
-    let get_goalstate_result = goalstate::get_goalstate(&client).await;
-    let vm_goalstate = match get_goalstate_result {
-        Ok(vm_goalstate) => vm_goalstate,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
+    let vm_goalstate = goalstate::get_goalstate(&client)
+        .await
+        .with_context(|| "Failed to get desired goalstate.")?;
+    goalstate::report_health(&client, vm_goalstate)
+        .await
+        .with_context(|| "Failed to report VM health.")?;
 
-    let report_health_result =
-        goalstate::report_health(&client, vm_goalstate).await;
-    match report_health_result {
-        Ok(report_health) => report_health,
-        Err(_err) => std::process::exit(exitcode::CONFIG),
-    };
+    Ok(())
 }

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -95,7 +95,9 @@ async fn main() {
 
     file_path.push_str("/.ssh");
 
-    user::set_ssh_keys(keys, username.to_string(), file_path.clone()).await;
+    user::set_ssh_keys(keys, username.to_string(), file_path.clone())
+        .await
+        .unwrap();
 
     println!();
     println!("Attempting to set the VM hostname");


### PR DESCRIPTION
Rather than panicking in library calls, return errors. These errors are definitely not perfect (they may be more or less fine-grained than library users need) but are intended to be a place to start.

Note: I'll rebase this once #57 is merged since it'll conflict with that.