### PR TITLE
libazureinit: Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+## libazureinit
+
+For common library used by this reference implementation, please refer to [libazureinit](https://github.com/Azure/azure-init/tree/main/libazureinit/).

--- a/libazureinit/README.md
+++ b/libazureinit/README.md
@@ -1,0 +1,16 @@
+# libazureinit
+
+A common library for provisioning Linux VMs on Azure.
+
+Features:
+
+* retrieve provisioning metadata from Azure Instance Metadata Service
+* configure the VM according to the provisioning metadata
+* report provisioning complete to Azure platform
+* basic features for instance initialisation
+
+[azure-init](https://github.com/Azure/azure-init) is a reference implementation that leverages the APIs provided by libazureinit.
+
+The goal is to provide APIs for other components to perform VM provisioning on Azure platform.
+
+For other instructions, like installing Rust, building the project, testing, etc. please refer to [azure-init's README](https://github.com/Azure/azure-init/blob/main/README.md).


### PR DESCRIPTION
Add initial README in `libazureinit`, to be published to its `crates.io` website as well.

Add a link to `libazureinit` on the top-level `azure-init` README.