### PR TITLE
Create clippy-linting.yml

### DIFF
--- a/.github/workflows/clippy-linting.yml
+++ b/.github/workflows/clippy-linting.yml
@@ -1,0 +1,22 @@
+name: "Run Clippy for Linting"
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+      - cron: '0 0 * * 0'
+
+jobs:
+  clippy:
+    name: Run clippy on azure-init 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features --verbose -- --deny warnings


### PR DESCRIPTION
Creating separate workflow for running clippy linting tool.

At some point it might be worth generating some kind of email notification in ICM (We have one for a separate internal repo) to alert when something fails and/or uploading the clippy logs as artifacts to be able to review later on, but will hold off on that for now. 