### PR TITLE
libazureinit: get mounted CDROM device at runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ jobs:
     name: Build and test azure-init
     runs-on: ubuntu-latest
     steps:
+      - name: Install libudev
+        run: |
+          sudo apt update
+          sudo apt install -y libudev-dev
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/clippy-linting.yml
+++ b/.github/workflows/clippy-linting.yml
@@ -11,6 +11,10 @@ jobs:
     name: Run clippy on azure-init 
     runs-on: ubuntu-latest
     steps:
+      - name: Install libudev
+        run: |
+          sudo apt update
+          sudo apt install -y libudev-dev
       - uses: actions/checkout@v4
       - name: Install rust
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/clippy-linting.yml
+++ b/.github/workflows/clippy-linting.yml
@@ -16,8 +16,8 @@ jobs:
           sudo apt update
           sudo apt install -y libudev-dev
       - uses: actions/checkout@v4
-      - name: Install rust
       - uses: actions-rs/toolchain@v1
+        name: Install rust
         with:
           profile: minimal
           toolchain: stable

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -19,6 +19,7 @@ xml-rs = "0.8.13"
 serde_json = "1.0.96"
 nix = {version = "0.28.0", features = ["fs", "user"]}
 libc = "0.2.146"
+block-utils = "0.11.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -29,4 +29,6 @@ pub enum Error {
     UserMissing { user: String },
     #[error("Provisioning a user with a non-empty password is not supported")]
     NonEmptyPassword,
+    #[error("Unable to get list of block devices")]
+    BlockUtils(#[from] block_utils::BlockUtilsError),
 }

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -14,7 +14,7 @@ use serde_xml_rs::from_str;
 
 use crate::error::Error;
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct Environment {
     #[serde(rename = "ProvisioningSection")]
     pub provisioning_section: ProvisioningSection,
@@ -22,7 +22,7 @@ pub struct Environment {
     pub platform_settings_section: PlatformSettingsSection,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct ProvisioningSection {
     #[serde(rename = "Version")]
     pub version: String,
@@ -30,7 +30,7 @@ pub struct ProvisioningSection {
     pub linux_prov_conf_set: LinuxProvisioningConfigurationSet,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct LinuxProvisioningConfigurationSet {
     #[serde(rename = "UserName")]
     pub username: String,
@@ -40,7 +40,7 @@ pub struct LinuxProvisioningConfigurationSet {
     pub hostname: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct PlatformSettingsSection {
     #[serde(rename = "Version")]
     pub version: String,
@@ -48,7 +48,7 @@ pub struct PlatformSettingsSection {
     pub platform_settings: PlatformSettings,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct PlatformSettings {
     #[serde(default = "default_preprov", rename = "PreprovisionedVm")]
     pub preprovisioned_vm: bool,
@@ -70,6 +70,22 @@ fn default_preprov_type() -> String {
 
 pub const PATH_MOUNT_DEVICE: &str = "/dev/sr0";
 pub const PATH_MOUNT_POINT: &str = "/run/azure-init/media/";
+
+const CDROM_VALID_FS: &[&str] = &["iso9660", "udf"];
+
+// Get a mounted device with any filesystem for CDROM
+pub fn get_mount_device() -> Result<Vec<String>, Error> {
+    let mut list_devices: Vec<String> = Vec::new();
+
+    while let Some(device) = block_utils::get_mounted_devices()?
+        .into_iter()
+        .find(|dev| CDROM_VALID_FS.contains(&dev.fs_type.to_str()))
+    {
+        list_devices.push(device.name);
+    }
+
+    Ok(list_devices)
+}
 
 // Some zero-sized structs that just provide states for our state machine
 pub struct Mounted;


### PR DESCRIPTION
Get mounted device name of CDROM at runtime, instead of hard-coding `/dev/sr0`.

Fixes https://github.com/Azure/azure-init/issues/66

## Testing done

TBD