### PR TITLE
split out mount/OVF logic into get_environment

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libazureinit"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.76"
 repository = "https://github.com/Azure/azure-init/"
 homepage = "https://github.com/Azure/azure-init/"
 license = "MIT"
@@ -20,6 +21,7 @@ serde_json = "1.0.96"
 nix = {version = "0.28.0", features = ["fs", "user"]}
 libc = "0.2.146"
 block-utils = "0.11.1"
+tracing = "0.1.40"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
As mount/OVF logic should be separate from `get_username()`, split it out into a new function `get_environment()`.

Fixes https://github.com/Azure/azure-init/issues/81