### PR TITLE
add Azure Linux support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "A reference implementation for provisioning Linux VMs on Azure."
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+os-release = "0.1.0"
 
 [dependencies.libazureinit]
 path = "libazureinit"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -18,6 +18,7 @@ xml-rs = "0.8.13"
 serde_json = "1.0.96"
 nix = "0.26.2"
 libc = "0.2.146"
+os-release = "0.1.0"
 
 [lib]
 name = "libazureinit"

--- a/libazureinit/src/user.rs
+++ b/libazureinit/src/user.rs
@@ -20,6 +20,7 @@ pub async fn set_ssh_keys(
     let mut authorized_keys_path = file_path;
     authorized_keys_path.push_str("/authorized_keys");
 
+    println!("authorized_keys_path: {:?}", authorized_keys_path);
     let mut authorized_keys =
         File::create(authorized_keys_path.clone()).unwrap();
     for key in keys {
@@ -30,17 +31,17 @@ pub async fn set_ssh_keys(
     let mut new_permissions = permissions.clone();
     new_permissions.set_mode(0o600);
     fs::set_permissions(authorized_keys_path.clone(), new_permissions).unwrap();
-
+    
     let uid_username = CString::new(username.clone()).unwrap();
     let uid_passwd = unsafe { libc::getpwnam(uid_username.as_ptr()) };
     let uid = unsafe { (*uid_passwd).pw_uid };
     let new_uid = Uid::from_raw(uid);
-
+    
     let gid_groupname = CString::new(username.clone()).unwrap();
     let gid_group = unsafe { libc::getgrnam(gid_groupname.as_ptr()) };
     let gid = unsafe { (*gid_group).gr_gid };
     let new_gid = Gid::from_raw(gid);
-
+    
     let _set_ownership = nix::unistd::chown(
         authorized_keys_path.as_str(),
         Some(new_uid),
@@ -54,27 +55,24 @@ pub async fn create_ssh_directory(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut file_path = home_path.to_owned();
     file_path.push_str("/.ssh");
-
     create_dir(file_path.clone())?;
-
     let uid_username = CString::new(username).unwrap();
     let uid_passwd = unsafe { libc::getpwnam(uid_username.as_ptr()) };
     let uid = unsafe { (*uid_passwd).pw_uid };
     let new_uid = Uid::from_raw(uid);
-
     let gid_groupname = CString::new(username).unwrap();
     let gid_group = unsafe { libc::getgrnam(gid_groupname.as_ptr()) };
     let gid = unsafe { (*gid_group).gr_gid };
     let new_gid = Gid::from_raw(gid);
-
+    
     let _set_ownership =
-        nix::unistd::chown(file_path.as_str(), Some(new_uid), Some(new_gid));
-
+    nix::unistd::chown(file_path.as_str(), Some(new_uid), Some(new_gid));
+    
     let metadata = fs::metadata(&file_path).unwrap();
     let permissions = metadata.permissions();
     let mut new_permissions = permissions.clone();
     new_permissions.set_mode(0o700);
     fs::set_permissions(&file_path, new_permissions).unwrap();
-
+    
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,30 @@
 
 use libazureinit::distro::{Distribution, Distributions};
 use libazureinit::{goalstate, imds, media, user};
+use os_release::OsRelease;
 
 #[tokio::main]
 async fn main() {
+    println!("Starting Provisioning...");
+    println!("Querying IMDS...");
     let query_result = imds::query_imds().await;
     let imds_body = match query_result {
         Ok(imds_body) => imds_body,
         Err(_err) => return,
     };
 
+    println!("Getting provisioning details...");
     let provision_with_password = imds::get_provision_with_password(&imds_body);
     let disable_authentication = match provision_with_password {
         Ok(disable_authentication) => disable_authentication,
         Err(_err) => return,
     };
 
+    println!("disable auth is set to: {}", disable_authentication);
     let username;
     let mut password = "".to_owned();
 
+    println!("Provisioning user...");
     if !disable_authentication {
         media::make_temp_directory().unwrap();
 
@@ -47,18 +53,26 @@ async fn main() {
             Ok(username) => username,
             Err(_err) => return,
         };
+        println!("Getting username... {}", username.as_str());
     }
 
     let mut file_path = "/home/".to_string();
     file_path.push_str(username.as_str());
 
-    Distributions::from("ubuntu")
+    let _os_release = match OsRelease::new() {
+        Ok(os_release) => os_release,
+        Err(_err) => return,
+    };
+    println!("Found OS: {}", _os_release.id.as_str());
+
+    Distributions::from(_os_release.id.as_str())
         .create_user(username.as_str(), password.as_str())
         .expect("Failed to create user");
     let _create_directory =
         user::create_ssh_directory(username.as_str(), &file_path).await;
-
+    println!("User's SSH directory was successfully created");
     let get_ssh_key_result = imds::get_ssh_keys(imds_body.clone());
+    println!("Getting SSH keys...");
     let keys = match get_ssh_key_result {
         Ok(keys) => keys,
         Err(_err) => return,
@@ -66,27 +80,33 @@ async fn main() {
 
     file_path.push_str("/.ssh");
 
+    println!("Setting SSH keys...");
     user::set_ssh_keys(keys, username.to_string(), file_path.clone()).await;
 
+    println!("Setting hostname...");
     let get_hostname_result = imds::get_hostname(imds_body.clone());
     let hostname = match get_hostname_result {
         Ok(hostname) => hostname,
         Err(_err) => return,
     };
 
-    Distributions::from("ubuntu")
+    println!("Setting hostname to: {}", hostname.as_str());
+    Distributions::from(_os_release.id.as_str())
         .set_hostname(hostname.as_str())
         .expect("Failed to set hostname");
 
+    println!("Getting goal state...");
     let get_goalstate_result = goalstate::get_goalstate().await;
     let vm_goalstate = match get_goalstate_result {
         Ok(vm_goalstate) => vm_goalstate,
         Err(_err) => return,
     };
 
+    println!("Reporting health...");
     let report_health_result = goalstate::report_health(vm_goalstate).await;
     match report_health_result {
         Ok(report_health) => report_health,
         Err(_err) => return,
     };
+    println!("Provisioning completed successfully.");
 }


### PR DESCRIPTION
This PR adds support for Azure Linux to the 0.1.1 version of azure-init. I need to rebase to the current head of main, while I do this, I'm marking the PR as draft to facilitate discussion. 

A notable delta between distros is the addition of the "wheel" and "sudo" groups and removal of the other groups in useradd.  

Additionally, this PR adds the os-release crate to determine the OS azure-init is operating on during provisioning time.

Finally, Functional tests for AzureLinux are missing. An update of the functional test to support either Azure Linux OR Ubuntu is a goal. I'm happy to make this change to the functional test in this PR or in a separate PR at the maintainer's request.

