### PR TITLE
improve image_creation script

### DIFF
--- a/demo/customdata_template.yml
+++ b/demo/customdata_template.yml
@@ -20,6 +20,7 @@ write_files:
       tar -xf /run/azure-init.tgz -C /var/lib
       mv /var/lib/azure-init/azure-init.service /lib/systemd/system/azure-init.service
       systemctl enable /lib/systemd/system/azure-init.service
+      mkdir --parents /etc/netplan
       cat > /etc/netplan/eth0.yaml <<EOF
       network:
           ethernets:
@@ -51,7 +52,7 @@ write_files:
       apt-get remove -y cloud-init walinuxagent
 
       # remove cloud-init netplan config
-      rm /etc/netplan/50-cloud-init.yaml
+      rm -f /etc/netplan/50-cloud-init.yaml
 
       echo "SIGTOOL_END"
 


### PR DESCRIPTION
Improve `image_creation.sh` script.

* Make necessary variables configurable like resource group, storage account, location, vm_name, vm_size, etc.
* Consolidate storage accounts creation into a single account, to avoid defining custom connection string env variables. Instead, generate connection string from the storage account directly to pass it to the subsequent commands.
* Create storage account and container before getting SAS string.
* Create SIG gallery before running az sig image-version create.
* Convert variable names to capital letters.
* Create image-definition before creating image-version in an automated way.
* Explicitly set `SecurityType=TrustedLaunch` for vm create and sig image-definition create.
* Address warnings and infos when running shellcheck, mainly by adding quotes around variables.
* Add command line options -h for help and -v for verbose.

## How to run with custom parameters.
```
RG="my-test-azinit" LOCATION="westeurope" VM_SIZE="Standard_D2ds_v5" BASE_IMAGE="Debian:debian-11:11-backports-gen2:latest" demo/image_creation.sh
```
## Testing done
Done testing with a couple of possible variables.