### PR TITLE
Implement a builder-style provisioning API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,12 @@ path = "tests/functional_tests.rs"
 members = [
     "libazureinit",
 ]
+
+[features]
+passwd = []
+hostnamectl = []
+useradd = []
+
+systemd_linux = ["passwd", "hostnamectl", "useradd"]
+
+default = ["systemd_linux"]

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.96"
 nix = {version = "0.29.0", features = ["fs", "user"]}
 block-utils = "0.11.1"
 tracing = "0.1.40"
+strum = { version = "0.26.3", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -31,4 +31,16 @@ pub enum Error {
     NonEmptyPassword,
     #[error("Unable to get list of block devices")]
     BlockUtils(#[from] block_utils::BlockUtilsError),
+    #[error(
+        "Failed to set the hostname; none of the provided backends succeeded"
+    )]
+    NoHostnameProvisioner,
+    #[error(
+        "Failed to create a user; none of the provided backends succeeded"
+    )]
+    NoUserProvisioner,
+    #[error(
+        "Failed to set the user password; none of the provided backends succeeded"
+    )]
+    NoPasswordProvisioner,
 }

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -57,6 +57,15 @@ pub struct PublicKeys {
     pub path: String,
 }
 
+impl From<&str> for PublicKeys {
+    fn from(value: &str) -> Self {
+        Self {
+            key_data: value.to_string(),
+            path: String::new(),
+        }
+    }
+}
+
 /// Deserializer that handles the string "true" and "false" that the IMDS API returns.
 fn string_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-pub mod distro;
 pub mod error;
 pub mod goalstate;
 pub mod imds;
 pub mod media;
-pub mod user;
+
+mod provision;
+pub use provision::{
+    hostname::Provisioner as HostnameProvisioner,
+    password::Provisioner as PasswordProvisioner,
+    user::{Provisioner as UserProvisioner, User},
+    Provision,
+};
 
 // Re-export as the Client is used in our API.
 pub use reqwest;

--- a/libazureinit/src/provision/hostname.rs
+++ b/libazureinit/src/provision/hostname.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::process::Command;
+
+use tracing::instrument;
+
+use crate::error::Error;
+
+/// Available tools to set the host's hostname.
+#[derive(strum::EnumIter, Debug, Clone)]
+#[non_exhaustive]
+pub enum Provisioner {
+    /// Use the `hostnamectl` command from `systemd`.
+    Hostnamectl,
+    #[cfg(test)]
+    FakeHostnamectl,
+}
+
+impl Provisioner {
+    pub(crate) fn set(&self, hostname: impl AsRef<str>) -> Result<(), Error> {
+        match self {
+            Self::Hostnamectl => hostnamectl(hostname.as_ref()),
+            #[cfg(test)]
+            Self::FakeHostnamectl => Ok(()),
+        }
+    }
+}
+
+#[instrument(skip_all)]
+fn hostnamectl(hostname: &str) -> Result<(), Error> {
+    let path_hostnamectl = env!("PATH_HOSTNAMECTL");
+
+    let status = Command::new(path_hostnamectl)
+        .arg("set-hostname")
+        .arg(hostname)
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::SubprocessFailed {
+            command: path_hostnamectl.to_string(),
+            status,
+        })
+    }
+}

--- a/libazureinit/src/provision/mod.rs
+++ b/libazureinit/src/provision/mod.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+pub mod hostname;
+pub mod password;
+pub(crate) mod ssh;
+pub mod user;
+
+use strum::IntoEnumIterator;
+use tracing::instrument;
+
+use crate::error::Error;
+use crate::User;
+
+/// The interface for applying the desired configuration to the host.
+///
+/// By default, all known tools for provisioning a particular resource are tried
+/// until one succeeds. Particular tools can be selected via the
+/// `*_provisioners()` methods ([`Provision::hostname_provisioners`],
+/// [`Provision::user_provisioners`], etc).
+///
+/// To actually apply the configuration, use [`Provision::provision`].
+#[derive(Clone)]
+pub struct Provision {
+    hostname: String,
+    user: User,
+    hostname_backends: Option<Vec<hostname::Provisioner>>,
+    user_backends: Option<Vec<user::Provisioner>>,
+    password_backends: Option<Vec<password::Provisioner>>,
+}
+
+impl Provision {
+    pub fn new(hostname: impl Into<String>, user: User) -> Self {
+        Self {
+            hostname: hostname.into(),
+            user,
+            hostname_backends: None,
+            user_backends: None,
+            password_backends: None,
+        }
+    }
+
+    /// Specify the ways to set the virtual machine's hostname.
+    ///
+    /// By default, all known methods will be attempted. Use this function to
+    /// restrict which methods are attempted. These will be attempted in the
+    /// order provided until one succeeds.
+    pub fn hostname_provisioners(
+        mut self,
+        backends: impl Into<Vec<hostname::Provisioner>>,
+    ) -> Self {
+        self.hostname_backends = Some(backends.into());
+        self
+    }
+
+    /// Specify the ways to create a user in the virtual machine
+    ///
+    /// By default, all known methods will be attempted. Use this function to
+    /// restrict which methods are attempted. These will be attempted in the
+    /// order provided until one succeeds.
+    pub fn user_provisioners(
+        mut self,
+        backends: impl Into<Vec<user::Provisioner>>,
+    ) -> Self {
+        self.user_backends = Some(backends.into());
+        self
+    }
+
+    /// Specify the ways to set a users password.
+    ///
+    /// By default, all known methods will be attempted. Use this function to
+    /// restrict which methods are attempted. These will be attempted in the
+    /// order provided until one succeeds. Only relevant if a password has been
+    /// provided with the [`User`].
+    pub fn password_provisioners(
+        mut self,
+        backend: impl Into<Vec<password::Provisioner>>,
+    ) -> Self {
+        self.password_backends = Some(backend.into());
+        self
+    }
+
+    /// Provision the host.
+    ///
+    /// Provisioning can fail if the host lacks the necessary tools. For example,
+    /// if there is no `useradd` command on the system's `PATH`, or if the command
+    /// returns an error, this will return an error. It does not attempt to undo
+    /// partial provisioning.
+    #[instrument(skip_all)]
+    pub fn provision(self) -> Result<(), Error> {
+        self.user_backends
+            .unwrap_or_else(|| user::Provisioner::iter().collect())
+            .iter()
+            .find_map(|backend| {
+                backend
+                    .create(&self.user)
+                    .map_err(|e| {
+                        tracing::info!(
+                            error=?e,
+                            backend=?backend,
+                            resource="user",
+                            "Provisioning did not succeed"
+                        );
+                        e
+                    })
+                    .ok()
+            })
+            .ok_or(Error::NoUserProvisioner)?;
+
+        self.password_backends
+            .unwrap_or_else(|| password::Provisioner::iter().collect())
+            .iter()
+            .find_map(|backend| {
+                backend
+                    .set(&self.user)
+                    .map_err(|e| {
+                        tracing::info!(
+                            error=?e,
+                            backend=?backend,
+                            resource="password",
+                            "Provisioning did not succeed"
+                        );
+                        e
+                    })
+                    .ok()
+            })
+            .ok_or(Error::NoPasswordProvisioner)?;
+
+        if !self.user.ssh_keys.is_empty() {
+            let user = nix::unistd::User::from_name(&self.user.name)?.ok_or(
+                Error::UserMissing {
+                    user: self.user.name,
+                },
+            )?;
+            ssh::provision_ssh(&user, &self.user.ssh_keys)?;
+        }
+
+        self.hostname_backends
+            .unwrap_or_else(|| hostname::Provisioner::iter().collect())
+            .iter()
+            .find_map(|backend| {
+                backend
+                    .set(&self.hostname)
+                    .map_err(|e| {
+                        tracing::info!(
+                            error=?e,
+                            backend=?backend,
+                            resource="hostname",
+                            "Provisioning did not succeed"
+                        );
+                        e
+                    })
+                    .ok()
+            })
+            .ok_or(Error::NoHostnameProvisioner)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::User;
+
+    use super::{hostname, password, user, Provision};
+
+    #[test]
+    fn test_successful_provision() {
+        let _p = Provision::new(
+            "my-hostname".to_string(),
+            User::new("azureuser", vec![]),
+        )
+        .hostname_provisioners([hostname::Provisioner::FakeHostnamectl])
+        .user_provisioners([user::Provisioner::FakeUseradd])
+        .password_provisioners([password::Provisioner::FakePasswd])
+        .provision()
+        .unwrap();
+    }
+}

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::process::Command;
+
+use tracing::instrument;
+
+use crate::{error::Error, User};
+
+/// Available tools to set the user's password (if a password is provided).
+#[derive(strum::EnumIter, Debug, Clone)]
+#[non_exhaustive]
+pub enum Provisioner {
+    /// Use the `passwd` command from `shadow-utils`.
+    Passwd,
+    #[cfg(test)]
+    FakePasswd,
+}
+
+impl Provisioner {
+    pub(crate) fn set(&self, user: &User) -> Result<(), Error> {
+        match self {
+            Self::Passwd => passwd(user),
+            #[cfg(test)]
+            Self::FakePasswd => Ok(()),
+        }
+    }
+}
+
+#[instrument(skip_all)]
+fn passwd(user: &User) -> Result<(), Error> {
+    let path_passwd = env!("PATH_PASSWD");
+
+    if user.password.is_none() {
+        let status = Command::new(path_passwd)
+            .arg("-d")
+            .arg(&user.name)
+            .status()?;
+        if !status.success() {
+            return Err(Error::SubprocessFailed {
+                command: path_passwd.to_string(),
+                status,
+            });
+        }
+    } else {
+        // creating user with a non-empty password is not allowed.
+        return Err(Error::NonEmptyPassword);
+    }
+
+    Ok(())
+}

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -12,19 +12,6 @@ use tracing::instrument;
 use crate::error::Error;
 use crate::imds::PublicKeys;
 
-pub fn set_ssh_keys(
-    keys: Vec<PublicKeys>,
-    username: impl AsRef<str>,
-) -> Result<(), Error> {
-    let user =
-        nix::unistd::User::from_name(username.as_ref())?.ok_or_else(|| {
-            Error::UserMissing {
-                user: username.as_ref().to_string(),
-            }
-        })?;
-    provision_ssh(&user, &keys)
-}
-
 #[instrument(skip_all, name = "ssh")]
 pub(crate) fn provision_ssh(
     user: &nix::unistd::User,

--- a/libazureinit/src/provision/user.rs
+++ b/libazureinit/src/provision/user.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::process::Command;
+
+use tracing::instrument;
+
+use crate::{error::Error, imds::PublicKeys};
+
+/// The user and its related configuration to create on the host.
+///
+/// A bare minimum user includes a name and a set of SSH public keys to allow the user to
+/// log into the host. Additional configuration includes a set of supplementary groups to
+/// add the user to, and a password to set for the user.
+///
+/// By default, the user is included in the `wheel` group which is often used to
+/// grant administrator privileges via the `sudo` command. This can be changed with the
+/// [`User::with_groups`] method.
+///
+/// # Example
+///
+/// ```
+/// # use libazureinit::User;
+/// let user = User::new("azure-user", ["ssh-ed25519 NOTAREALKEY".into()])
+///     .with_groups(["wheel".to_string(), "dialout".to_string()]);
+/// ```
+#[derive(Clone)]
+pub struct User {
+    pub(crate) name: String,
+    pub(crate) groups: Vec<String>,
+    pub(crate) ssh_keys: Vec<PublicKeys>,
+    pub(crate) password: Option<String>,
+}
+
+impl core::fmt::Debug for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // This is manually implemented to avoid printing the password if it's set
+        f.debug_struct("User")
+            .field("name", &self.name)
+            .field("groups", &self.groups)
+            .field("ssh_keys", &self.ssh_keys)
+            .field("password", &self.password.is_some())
+            .finish()
+    }
+}
+
+impl User {
+    /// Configure the user being provisioned on the host.
+    ///
+    /// What constitutes a valid username depends on the host configuration and
+    /// no validation will occur prior to provisioning the host.
+    pub fn new(
+        name: impl Into<String>,
+        ssh_keys: impl Into<Vec<PublicKeys>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            groups: vec!["wheel".into()],
+            ssh_keys: ssh_keys.into(),
+            password: None,
+        }
+    }
+
+    /// Set a password for the user; this is optional.
+    pub fn with_password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    /// A list of supplemental group names to add the user to.
+    ///
+    /// If any of the groups do not exist on the host, provisioning will fail.
+    pub fn with_groups(mut self, groups: impl Into<Vec<String>>) -> Self {
+        self.groups = groups.into();
+        self
+    }
+}
+
+/// Available tools to create the user.
+#[derive(strum::EnumIter, Debug, Clone)]
+#[non_exhaustive]
+pub enum Provisioner {
+    /// Use the `useradd` command from `shadow-utils`.
+    Useradd,
+    #[cfg(test)]
+    FakeUseradd,
+}
+
+impl Provisioner {
+    pub(crate) fn create(&self, user: &User) -> Result<(), Error> {
+        match self {
+            Self::Useradd => useradd(user),
+            #[cfg(test)]
+            Self::FakeUseradd => Ok(()),
+        }
+    }
+}
+
+#[instrument(skip_all)]
+fn useradd(user: &User) -> Result<(), Error> {
+    let path_useradd = env!("PATH_USERADD");
+    let home_path = format!("/home/{}", user.name);
+
+    let status = Command::new(path_useradd)
+                    .arg(&user.name)
+                    .arg("--comment")
+                    .arg(
+                      "Provisioning agent created this user based on username provided in IMDS",
+                    )
+                    .arg("--groups")
+                    .arg(user.groups.join(","))
+                    .arg("-d")
+                    .arg(home_path)
+                    .arg("-m")
+                    .status()?;
+    if !status.success() {
+        return Err(Error::SubprocessFailed {
+            command: path_useradd.to_string(),
+            status,
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::User;
+
+    #[test]
+    fn password_skipped_in_debug() {
+        let user_with_password =
+            User::new("azureuser", []).with_password("hunter2");
+        let user_without_password = User::new("azureuser", []);
+
+        assert_eq!(
+            "User { name: \"azureuser\", groups: [\"wheel\"], ssh_keys: [], password: true }",
+            format!("{:?}", user_with_password)
+        );
+        assert_eq!(
+            "User { name: \"azureuser\", groups: [\"wheel\"], ssh_keys: [], password: false }",
+            format!("{:?}", user_without_password)
+        );
+    }
+}


### PR DESCRIPTION
This is based on top of PR https://github.com/Azure/azure-init/pull/86 so I'd recommend just looking at the last commit in the series. It is a first draft of a builder-style interface to allow library users to select the backend for tools when provisioning.

It's not ready to be merged since there's no tests, documentation, or
implementation of default behavior when no backend is explicitly
selected. Additionally, I've not gated backends behind feature flags,
either. I'd love feedback on the general approach and what to do by
default.

My personal opinion is that the default option should iterate through
all available backends until one succeeds.