### PR TITLE
libazureinit: remove requirement of minimum Rust version

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -2,7 +2,6 @@
 name = "libazureinit"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.76"
 build = "build.rs"
 repository = "https://github.com/Azure/azure-init/"
 homepage = "https://github.com/Azure/azure-init/"

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -193,16 +193,18 @@ pub fn parse_ovf_env(ovf_body: &str) -> Result<Environment, Error> {
 pub fn mount_parse_ovf_env(dev: String) -> Result<Environment, Error> {
     let mount_media =
         Media::new(PathBuf::from(dev), PathBuf::from(PATH_MOUNT_POINT));
-    let mounted = mount_media.mount().inspect_err(
-        |e| tracing::error!(error = ?e, "Failed to mount media."),
-    )?;
+    let mounted = mount_media.mount().map_err(|e| {
+        tracing::error!(error = ?e, "Failed to mount media.");
+        e
+    })?;
 
     let ovf_body = mounted.read_ovf_env_to_string()?;
     let environment = parse_ovf_env(ovf_body.as_str())?;
 
-    mounted.unmount().inspect_err(
-        |e| tracing::error!(error = ?e, "Failed to remove media."),
-    )?;
+    mounted.unmount().map_err(|e| {
+        tracing::error!(error = ?e, "Failed to remove media.");
+        e
+    })?;
 
     Ok(environment)
 }


### PR DESCRIPTION
Replace `inspect_err` with `map_err`, to remove requirement of the minimum Rust version from 1.76, which is apparently not wide-spread enough in other development environments.

See also https://github.com/Azure/azure-init/pull/84#pullrequestreview-2086317824.

/cc @SeanDougherty