### PR TITLE
.github: migrate to dtolnay/rust-toolchain to build with old toolchains

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,35 +11,24 @@ jobs:
   build-test:
     name: Build and test azure-init
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust-toolchain: [stable, stable 12 months ago]
     steps:
       - name: Install libudev
         run: |
           sudo apt update
           sudo apt install -y libudev-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
+          toolchain: ${{matrix.rust-toolchain}}
+          components: clippy, rustfmt
       - name: Rustfmt Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check
       - name: Build azure-init
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Run unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --verbose -- --deny warnings
+        run: cargo clippy --verbose -- --deny warnings

--- a/.github/workflows/clippy-linting.yml
+++ b/.github/workflows/clippy-linting.yml
@@ -10,17 +10,18 @@ jobs:
   clippy:
     name: Run clippy on azure-init 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust-toolchain: [stable, stable 12 months ago]
     steps:
       - name: Install libudev
         run: |
           sudo apt update
           sudo apt install -y libudev-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        name: Install rust
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          toolchain: ${{matrix.rust-toolchain}}
+          components: clippy
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --verbose -- --deny warnings

--- a/libazureinit/src/distro.rs
+++ b/libazureinit/src/distro.rs
@@ -18,7 +18,7 @@ pub fn create_user_with_useradd(username: &str) -> Result<i32, Error> {
                     .arg("--groups")
                     .arg("adm,audio,cdrom,dialout,dip,floppy,lxd,netdev,plugdev,sudo,video")
                     .arg("-d")
-                    .arg(home_path.clone())
+                    .arg(home_path)
                     .arg("-m")
                     .status()?;
     if !status.success() {

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -113,7 +113,7 @@ impl Media<Unmounted> {
 
         let metadata = fs::metadata(&self.mount_path)?;
         let permissions = metadata.permissions();
-        let mut new_permissions = permissions.clone();
+        let mut new_permissions = permissions;
         new_permissions.set_mode(0o700);
         fs::set_permissions(&self.mount_path, new_permissions)?;
 

--- a/libazureinit/src/user.rs
+++ b/libazureinit/src/user.rs
@@ -27,7 +27,7 @@ pub async fn set_ssh_keys(
     }
     let metadata = fs::metadata(authorized_keys_path.clone())?;
     let permissions = metadata.permissions();
-    let mut new_permissions = permissions.clone();
+    let mut new_permissions = permissions;
     new_permissions.set_mode(0o600);
     fs::set_permissions(authorized_keys_path.clone(), new_permissions)?;
 
@@ -36,7 +36,7 @@ pub async fn set_ssh_keys(
     let uid = unsafe { (*uid_passwd).pw_uid };
     let new_uid = Uid::from_raw(uid);
 
-    let gid_groupname = CString::new(username.clone())?;
+    let gid_groupname = CString::new(username)?;
     let gid_group = unsafe { libc::getgrnam(gid_groupname.as_ptr()) };
     let gid = unsafe { (*gid_group).gr_gid };
     let new_gid = Gid::from_raw(gid);
@@ -67,7 +67,7 @@ pub async fn create_ssh_directory(
 
     let metadata = fs::metadata(&file_path)?;
     let permissions = metadata.permissions();
-    let mut new_permissions = permissions.clone();
+    let mut new_permissions = permissions;
     new_permissions.set_mode(0o700);
     fs::set_permissions(&file_path, new_permissions)?;
 


### PR DESCRIPTION
Migrate to GitHub Actions [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain), to support multiple toolchains as well as an old toolchain like stable 12 months ago.

Note: it is not possible to go back to e.g. 18 months ago, Rust [1.66.1](https://github.com/rust-lang/rust/releases/tag/1.66.1) as of now, because then nix v0.29.0 of the current code base cannot be built, nix 0.29.0 requires rustc 1.69 or newer.

Now that CI needs to build source code with an old version 12 months ago, Rust 1.70, cargo clippy starts to print out warnings like below.

```rust
error: redundant clone
  --> libazureinit/src/distro.rs:21:35
   |
21 |                     .arg(home_path.clone())
   |                                   ^^^^^^^^ help: remove this
   |
 note: this value is dropped without further use
  --> libazureinit/src/distro.rs:21:26
   |
21 |                     .arg(home_path.clone())
   |                          ^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
   = note: `-D clippy::redundant-clone` implied by `-D warnings`
error: redundant clone
```

Fix redundant clone issue of clippy.

Fixes https://github.com/Azure/azure-init/issues/93.

## Testing done

Tested on my fork.