### PR TITLE
user: simplify ssh key provisioning and drop unsafe usage

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -16,12 +16,12 @@ tokio = { version = "1", features = ["full"] }
 serde-xml-rs = "0.6.0"
 serde_json = "1.0.96"
 nix = {version = "0.29.0", features = ["fs", "user"]}
-libc = "0.2.146"
 block-utils = "0.11.1"
 tracing = "0.1.40"
 
 [dev-dependencies]
 tempfile = "3"
+whoami = "1"
 
 [lib]
 name = "libazureinit"

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,19 +99,8 @@ async fn provision() -> Result<(), anyhow::Error> {
         || format!("Unabled to set an empty password for user '{username}'"),
     )?;
 
-    user::create_ssh_directory(username.as_str(), &file_path)
-        .await
-        .with_context(|| "Failed to create ssh directory.")?;
-
-    file_path.push_str("/.ssh");
-
-    user::set_ssh_keys(
-        instance_metadata.compute.public_keys,
-        username.to_string(),
-        file_path.clone(),
-    )
-    .await
-    .with_context(|| "Failed to write ssh public keys.")?;
+    user::set_ssh_keys(instance_metadata.compute.public_keys, &username)
+        .with_context(|| "Failed to write ssh public keys.")?;
 
     distro::set_hostname_with_hostnamectl(
         instance_metadata.compute.os_profile.computer_name.as_str(),

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -67,17 +67,6 @@ async fn main() {
 
     println!("User {} was successfully created", username.as_str());
 
-    println!();
-    println!("Attempting to create user's SSH directory");
-
-    let _create_directory =
-        user::create_ssh_directory(username.as_str(), &file_path).await;
-    match _create_directory {
-        Ok(create_directory) => create_directory,
-        Err(_err) => return,
-    };
-    println!("User's SSH directory was successfully created");
-
     let keys: Vec<PublicKeys> = vec![
         PublicKeys {
             path: "/path/to/.ssh/keys/".to_owned(),
@@ -93,11 +82,10 @@ async fn main() {
         },
     ];
 
-    file_path.push_str("/.ssh");
+    println!();
+    println!("Attempting to create user's SSH authorized_keys");
 
-    user::set_ssh_keys(keys, username.to_string(), file_path.clone())
-        .await
-        .unwrap();
+    user::set_ssh_keys(keys, username).unwrap();
 
     println!();
     println!("Attempting to set the VM hostname");


### PR DESCRIPTION
In order to correctly set the ownership of the authorized_keys file, the function was using libc directly with some unsafe blocks. It's tricky to correctly use the C APIs and in this case, both getpwnam() and getgrnam() return NULL if a matching entry isn't found or if an error occurred. Since we weren't checking the return value this would result in a null pointer dereference.

`nix` provides safe APIs to retrieve the user and group ids so rather than implementing it ourselves, just use those. This also refactors the two separate APIs for creating the directory and writing the keys to a single call that handles it all.

This is extracted from #91 as it's not really related to the API design.