### PR TITLE
ci: run libazureinit tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,6 @@ jobs:
       - name: Build azure-init
         run: cargo build --verbose
       - name: Run unit tests
-        run: cargo test --verbose
+        run: cargo test --verbose --all-features --workspace
       - name: Run clippy
         run: cargo clippy --verbose -- --deny warnings


### PR DESCRIPTION
Without the --workspace flag, cargo test just runs the tests for azure-init and not the library. While we don't currently use features, add the flag to enable all features in case we do in the future.

Compare the unit test section in this PRs CI run to [one from before this PR](https://github.com/Azure/azure-init/actions/runs/9767930511/job/26964325258)