### PR TITLE
libazureinit: remove unused dependencies

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -11,12 +11,9 @@ description = "A common library for provisioning Linux VMs on Azure."
 [dependencies]
 reqwest = { version = "0.12.0", default-features = false, features = ["blocking", "json"] }
 serde = {version = "1.0.163", features = ["derive"]}
-serde_xml = "0.9.1"
-serde_derive = "1.0"
 thiserror = "1.0.58"
 tokio = { version = "1", features = ["full"] }
 serde-xml-rs = "0.6.0"
-xml-rs = "0.8.13"
 serde_json = "1.0.96"
 nix = {version = "0.29.0", features = ["fs", "user"]}
 libc = "0.2.146"


### PR DESCRIPTION
Remove unsed dependency crates, `serde_derive`, `serde_xml`, `xml-rs`.
Detected by `cargo-machete`.

```
cargo-machete found the following unused dependencies in .../azure-init:
libazureinit -- .../azure-init/libazureinit/Cargo.toml:
        serde_derive
        serde_xml
        xml-rs
```
