### PR TITLE
Get username either by IMDS or from a local OVF file

### DIFF
--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     Nix(#[from] nix::Error),
     #[error("The user {user} does not exist")]
     UserMissing { user: String },
+    #[error("failed to get username from IMDS or local OVF files")]
+    UsernameFailure,
+    #[error("failed to get instance metadata from IMDS")]
+    InstanceMetadataFailure,
     #[error("Provisioning a user with a non-empty password is not supported")]
     NonEmptyPassword,
     #[error("Unable to get list of block devices")]

--- a/tests/functional_tests.sh
+++ b/tests/functional_tests.sh
@@ -41,18 +41,18 @@ else
 fi
 
 # Set the subscription you want to use
-az account set --subscription $SUBSCRIPTION_ID
+az account set --subscription "$SUBSCRIPTION_ID"
 
 # Create resource group
-az group create -g $RG -l $LOCATION
+az group create -g "$RG" -l "$LOCATION"
 
 echo "Creating VM..."
-az vm create -n $VM_NAME_WITH_TIMESTAMP \
--g $RG \
---image $VM_IMAGE \
---size $VM_SIZE \
---admin-username $VM_ADMIN_USERNAME \
---ssh-key-value $PATH_TO_PUBLIC_SSH_KEY \
+az vm create -n "$VM_NAME_WITH_TIMESTAMP" \
+-g "$RG" \
+--image "$VM_IMAGE" \
+--size "$VM_SIZE" \
+--admin-username "$VM_ADMIN_USERNAME" \
+--ssh-key-value "$PATH_TO_PUBLIC_SSH_KEY" \
 --public-ip-sku Standard \
 --security-type "$VM_SECURITY_TYPE"
 echo "VM successfully created"
@@ -61,13 +61,13 @@ echo "Sleeping to ensure SSH access set up"
 sleep 15
 
 echo "Getting VM Public IP Address..."
-PUBLIC_IP=$(az vm show -d -g $RG -n $VM_NAME_WITH_TIMESTAMP --query publicIps -o tsv)
-echo $PUBLIC_IP
+PUBLIC_IP=$(az vm show -d -g "$RG" -n "$VM_NAME_WITH_TIMESTAMP" --query publicIps -o tsv)
+echo "$PUBLIC_IP"
 
-scp -o StrictHostKeyChecking=no -i $PATH_TO_PRIVATE_SSH_KEY ./target/debug/functional_tests $VM_ADMIN_USERNAME@$PUBLIC_IP:~
+scp -o StrictHostKeyChecking=no -i "$PATH_TO_PRIVATE_SSH_KEY" ./target/debug/functional_tests "$VM_ADMIN_USERNAME"@"$PUBLIC_IP":~
 
 echo "Logging into VM..."
-ssh -o StrictHostKeyChecking=no -i $PATH_TO_PRIVATE_SSH_KEY $VM_ADMIN_USERNAME@$PUBLIC_IP 'sudo ./functional_tests test_user' 
+ssh -o StrictHostKeyChecking=no -i "$PATH_TO_PRIVATE_SSH_KEY" "$VM_ADMIN_USERNAME"@"$PUBLIC_IP" 'sudo ./functional_tests test_user'
 
 # Delete the resource group
-az group delete -g $RG --yes --no-wait
+az group delete -g "$RG" --yes --no-wait

--- a/tests/functional_tests.sh
+++ b/tests/functional_tests.sh
@@ -14,6 +14,7 @@ VM_SIZE="${VM_SIZE:-Standard_D2lds_v5}"
 VM_ADMIN_USERNAME="${VM_ADMIN_USERNAME:-azureuser}"
 AZURE_SSH_KEY_NAME="${AZURE_SSH_KEY_NAME:-azure-ssh-key}"
 VM_NAME_WITH_TIMESTAMP=$VM_NAME-$EPOCH
+VM_SECURITY_TYPE="${VM_SECURITY_TYPE:-TrustedLaunch}"
 
 set -e
 
@@ -52,7 +53,8 @@ az vm create -n $VM_NAME_WITH_TIMESTAMP \
 --size $VM_SIZE \
 --admin-username $VM_ADMIN_USERNAME \
 --ssh-key-value $PATH_TO_PUBLIC_SSH_KEY \
---public-ip-sku Standard
+--public-ip-sku Standard \
+--security-type "$VM_SECURITY_TYPE"
 echo "VM successfully created"
 
 echo "Sleeping to ensure SSH access set up"


### PR DESCRIPTION
Username can be obtained either via fetching instance metadata from IMDS or mounting a local device for OVF environment file. It should not fail immediately in a single failure, instead it should fall back to the other mechanism. So it is not a good idea to use `?` for `query()` or `get_environment()`.

Fixes https://github.com/Azure/azure-init/issues/99