### PR TITLE
Enable passwordless sudo for the user

### DIFF
--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -37,34 +37,9 @@ pub(crate) fn provision_ssh(
     Ok(())
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-pub fn add_user_for_passwordless_sudo(
-    username: &str,
-) -> Result<(), Error>{
-=======
 pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
     // Create a file under /etc/sudoers.d with azure-init-user
     let sudoers_path = "/etc/sudoers.d/azure-init-user";
-
-    let _ = File::create(sudoers_path)?;
->>>>>>> b523371 (Enable passwordless sudo for the user)
-    let mut sudoers_file = std::fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(sudoers_path)?;
-    write!(
-        sudoers_file,
-        "{} ALL=(ALL) NOPASSWD: ALL \n",
-        username.to_string()
-    )?;
-    sudoers_file.flush()?;
-<<<<<<< HEAD
-=======
-pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
-    // Create a file under /etc/sudoers.d with azure-init-user
-    let sudoers_path = "/etc/sudoers.d/azure-init-user";
-
     let _ = File::create(sudoers_path)?;
     let mut sudoers_file = std::fs::OpenOptions::new()
         .append(true)
@@ -76,20 +51,12 @@ pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
         username.to_string()
     )?;
     sudoers_file.flush()?;
-=======
->>>>>>> b523371 (Enable passwordless sudo for the user)
-
     // Set the permission
     let metadata = fs::metadata(sudoers_path)?;
     let permissions = metadata.permissions();
     let mut new_permissions = permissions.clone();
     new_permissions.set_mode(0o700);
     fs::set_permissions(sudoers_path, new_permissions)?;
-
-<<<<<<< HEAD
->>>>>>> 20f9d3f (Enable passwordless sudo for the user)
-=======
->>>>>>> b523371 (Enable passwordless sudo for the user)
     Ok(())
 }
 

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -37,6 +37,18 @@ pub(crate) fn provision_ssh(
     Ok(())
 }
 
+pub fn add_user_for_passwordless_sudo(
+    username: &str,
+) -> Result<(), Error>{
+    let mut sudoers_file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open("/etc/sudoers")?;
+    write!(sudoers_file, "{} ALL=(ALL) NOPASSWD: ALL \n", username.to_string())?;
+    sudoers_file.flush()?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -37,6 +37,7 @@ pub(crate) fn provision_ssh(
     Ok(())
 }
 
+<<<<<<< HEAD
 pub fn add_user_for_passwordless_sudo(
     username: &str,
 ) -> Result<(), Error>{
@@ -46,6 +47,31 @@ pub fn add_user_for_passwordless_sudo(
         .open("/etc/sudoers")?;
     write!(sudoers_file, "{} ALL=(ALL) NOPASSWD: ALL \n", username.to_string())?;
     sudoers_file.flush()?;
+=======
+pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
+    // Create a file under /etc/sudoers.d with azure-init-user
+    let sudoers_path = "/etc/sudoers.d/azure-init-user";
+
+    let _ = File::create(sudoers_path)?;
+    let mut sudoers_file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(sudoers_path)?;
+    write!(
+        sudoers_file,
+        "{} ALL=(ALL) NOPASSWD: ALL \n",
+        username.to_string()
+    )?;
+    sudoers_file.flush()?;
+
+    // Set the permission
+    let metadata = fs::metadata(sudoers_path)?;
+    let permissions = metadata.permissions();
+    let mut new_permissions = permissions.clone();
+    new_permissions.set_mode(0o700);
+    fs::set_permissions(sudoers_path, new_permissions)?;
+
+>>>>>>> 20f9d3f (Enable passwordless sudo for the user)
     Ok(())
 }
 

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -38,15 +38,28 @@ pub(crate) fn provision_ssh(
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 pub fn add_user_for_passwordless_sudo(
     username: &str,
 ) -> Result<(), Error>{
+=======
+pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
+    // Create a file under /etc/sudoers.d with azure-init-user
+    let sudoers_path = "/etc/sudoers.d/azure-init-user";
+
+    let _ = File::create(sudoers_path)?;
+>>>>>>> b523371 (Enable passwordless sudo for the user)
     let mut sudoers_file = std::fs::OpenOptions::new()
         .append(true)
         .create(true)
-        .open("/etc/sudoers")?;
-    write!(sudoers_file, "{} ALL=(ALL) NOPASSWD: ALL \n", username.to_string())?;
+        .open(sudoers_path)?;
+    write!(
+        sudoers_file,
+        "{} ALL=(ALL) NOPASSWD: ALL \n",
+        username.to_string()
+    )?;
     sudoers_file.flush()?;
+<<<<<<< HEAD
 =======
 pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
     // Create a file under /etc/sudoers.d with azure-init-user
@@ -63,6 +76,8 @@ pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
         username.to_string()
     )?;
     sudoers_file.flush()?;
+=======
+>>>>>>> b523371 (Enable passwordless sudo for the user)
 
     // Set the permission
     let metadata = fs::metadata(sudoers_path)?;
@@ -71,7 +86,10 @@ pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
     new_permissions.set_mode(0o700);
     fs::set_permissions(sudoers_path, new_permissions)?;
 
+<<<<<<< HEAD
 >>>>>>> 20f9d3f (Enable passwordless sudo for the user)
+=======
+>>>>>>> b523371 (Enable passwordless sudo for the user)
     Ok(())
 }
 

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -37,29 +37,6 @@ pub(crate) fn provision_ssh(
     Ok(())
 }
 
-pub fn add_user_for_passwordless_sudo(username: &str) -> Result<(), Error> {
-    // Create a file under /etc/sudoers.d with azure-init-user
-    let sudoers_path = "/etc/sudoers.d/azure-init-user";
-    let _ = File::create(sudoers_path)?;
-    let mut sudoers_file = std::fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(sudoers_path)?;
-    write!(
-        sudoers_file,
-        "{} ALL=(ALL) NOPASSWD: ALL \n",
-        username.to_string()
-    )?;
-    sudoers_file.flush()?;
-    // Set the permission
-    let metadata = fs::metadata(sudoers_path)?;
-    let permissions = metadata.permissions();
-    let mut new_permissions = permissions.clone();
-    new_permissions.set_mode(0o700);
-    fs::set_permissions(sudoers_path, new_permissions)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/libazureinit/src/provision/user.rs
+++ b/libazureinit/src/provision/user.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::process::Command;
+use std::{fs::Permissions, os::unix::fs::PermissionsExt, process::Command};
+
+use std::io::Write;
 
 use tracing::instrument;
 
@@ -88,11 +90,13 @@ pub enum Provisioner {
 
 impl Provisioner {
     pub(crate) fn create(&self, user: &User) -> Result<(), Error> {
-        match self {
+        let _ = match self {
             Self::Useradd => useradd(user),
             #[cfg(test)]
             Self::FakeUseradd => Ok(()),
-        }
+        };
+        let path = "/etc/sudoers.d/azure-init-user";
+        add_user_for_passwordless_sudo(user.name.clone(), path)
     }
 }
 
@@ -123,9 +127,38 @@ fn useradd(user: &User) -> Result<(), Error> {
     Ok(())
 }
 
+fn add_user_for_passwordless_sudo(
+    username: String,
+    path: &str,
+) -> Result<(), Error> {
+    // Create a file under /etc/sudoers.d with azure-init-user
+    let sudoers_path = path;
+    let mut sudoers_file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(sudoers_path)?;
+    write!(
+        sudoers_file,
+        "{} ALL=(ALL) NOPASSWD: ALL \n",
+        username.to_string()
+    )?;
+    sudoers_file.flush()?;
+    // Set the permission
+    sudoers_file.set_permissions(Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::{
+        fs::{self, Permissions},
+        os::unix::fs::PermissionsExt,
+    };
+
     use crate::User;
+
+    use super::add_user_for_passwordless_sudo;
+    const PATH: &str = "/tmp/test1";
 
     #[test]
     fn password_skipped_in_debug() {
@@ -140,6 +173,19 @@ mod tests {
         assert_eq!(
             "User { name: \"azureuser\", groups: [\"wheel\"], ssh_keys: [], password: false }",
             format!("{:?}", user_without_password)
+        );
+    }
+
+    #[test]
+    fn test_user_insecure() {
+        let user_insecure = User::new("azureuser", []);
+        let a = add_user_for_passwordless_sudo(user_insecure.name, PATH);
+        assert!(a.is_ok());
+        assert!(fs::metadata(PATH).is_ok(), "Specified file not created");
+        assert_eq!(
+            fs::Permissions(PATH).mode(),
+            Permissions.mode(0o600),
+            "Permissions are not set properly"
         );
     }
 }


### PR DESCRIPTION
Currently admin user is part of the sudoers
group, adding the user for passwordless sudo
from this issue #69

<!-- [ Describe the change in 1 - 3 paragraphs ] -->

## How to use

<!-- [ Describe what reviewers need to do in order to validate this PR ] -->

## Testing done

<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
