### PR TITLE
Swapping get_mount_devices from while loop to filter_map

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -24,7 +24,6 @@ fstab = "0.4.0"
 [dev-dependencies]
 tempfile = "3"
 whoami = "1"
-mockall = "0.11.0"
 
 [lib]
 name = "libazureinit"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -19,7 +19,7 @@ nix = {version = "0.29.0", features = ["fs", "user"]}
 block-utils = "0.11.1"
 tracing = "0.1.40"
 strum = { version = "0.26.3", features = ["derive"] }
-uuid = { version = "1.0", features = ["v4"] }
+fstab = "0.4.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -19,10 +19,12 @@ nix = {version = "0.29.0", features = ["fs", "user"]}
 block-utils = "0.11.1"
 tracing = "0.1.40"
 strum = { version = "0.26.3", features = ["derive"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"
 whoami = "1"
+mockall = "0.11.0"
 
 [lib]
 name = "libazureinit"

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -77,14 +77,17 @@ const CDROM_VALID_FS: &[&str] = &["iso9660", "udf"];
 
 // Get a mounted device with any filesystem for CDROM
 pub fn get_mount_device() -> Result<Vec<String>, Error> {
-    let mut list_devices: Vec<String> = Vec::new();
-
-    while let Some(device) = block_utils::get_mounted_devices()?
+    let devices = block_utils::get_mounted_devices()?;
+    let list_devices: Vec<String> = devices
         .into_iter()
-        .find(|dev| CDROM_VALID_FS.contains(&dev.fs_type.to_str()))
-    {
-        list_devices.push(device.name);
-    }
+        .filter_map(|dev| {
+            if CDROM_VALID_FS.contains(&dev.fs_type.to_str()) {
+                Some(dev.name)
+            } else {
+                None
+            }
+        })
+        .collect();
 
     Ok(list_devices)
 }

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -421,10 +421,10 @@ mod tests {
                 Device {
                     id: Some(Uuid::new_v4()),
                     name: "device1".to_string(),
-                    media_type: MediaType::NVME, // Adjust this to match the MediaType variants
+                    media_type: MediaType::NVME, 
                     device_type: DeviceType::Disk,
                     capacity: 700_000_000,
-                    fs_type: FilesystemType::Ntfs, // Adjust this to match the FilesystemType variants
+                    fs_type: FilesystemType::Ntfs, 
                     serial_number: Some("12345".to_string()),
                     logical_block_size: Some(512),
                     physical_block_size: Some(512),
@@ -432,7 +432,7 @@ mod tests {
                 Device {
                     id: Some(Uuid::new_v4()),
                     name: "device2".to_string(),
-                    media_type: MediaType::Rotational, // Adjust this to match the MediaType variants
+                    media_type: MediaType::Rotational, 
                     device_type: DeviceType::Disk,
                     capacity: 1_000_000_000,
                     fs_type: FilesystemType::Ext4,
@@ -443,10 +443,10 @@ mod tests {
                 Device {
                     id: Some(Uuid::new_v4()),
                     name: "device3".to_string(),
-                    media_type: MediaType::NVME, // Adjust this to match the MediaType variants
+                    media_type: MediaType::NVME, 
                     device_type: DeviceType::Disk,
                     capacity: 700_000_000,
-                    fs_type: FilesystemType::Xfs, // Adjust this to match the FilesystemType variants
+                    fs_type: FilesystemType::Xfs, 
                     serial_number: Some("54321".to_string()),
                     logical_block_size: Some(512),
                     physical_block_size: Some(512),

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -503,20 +503,4 @@ mod tests {
         let list_devices = result.unwrap();
         assert!(list_devices.is_empty());
     }
-
-    #[test]
-    fn test_get_mount_device_with_invalid_format() {
-        let mut temp_file =
-            NamedTempFile::new().expect("Failed to create temporary file");
-        let mount_table = r#"
-            invalid_format_entry
-        "#;
-        temp_file
-            .write_all(mount_table.as_bytes())
-            .expect("Failed to write to temporary file");
-        let temp_path = temp_file.into_temp_path();
-        let result = get_mount_device(Some(temp_path.as_ref()));
-
-        assert!(result.is_err());
-    }
 }

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -17,7 +17,7 @@ use tracing;
 use tracing::instrument;
 
 use crate::error::Error;
-use fstab::{FsEntry, FsTab};
+use fstab::FsTab;
 
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct Environment {
@@ -82,15 +82,15 @@ const MTAB_PATH: &str = "/etc/mtab";
 // Get a mounted device with any filesystem for CDROM
 #[instrument]
 pub fn get_mount_device(path: Option<&Path>) -> Result<Vec<String>, Error> {
-    let fstab = FsTab::new(path.unwrap_or(Path::new(MTAB_PATH)));
-    let entries: Vec<FsEntry> = fstab.get_entries()?;
+    let fstab = FsTab::new(path.unwrap_or_else(|| Path::new(MTAB_PATH)));
+    let entries = fstab.get_entries()?;
 
     // Retrieve the names of all devices that have cdrom-type filesystem (e.g., udf)
-    let cdrom_devices: Vec<String> = entries
+    let cdrom_devices = entries
         .into_iter()
         .filter_map(|entry| {
             if CDROM_VALID_FS.contains(&entry.vfs_type.as_str()) {
-                Some(entry.fs_spec.clone())
+                Some(entry.fs_spec)
             } else {
                 None
             }
@@ -433,7 +433,6 @@ mod tests {
         let temp_path = temp_file.into_temp_path();
         let result = get_mount_device(Some(temp_path.as_ref()));
 
-        assert!(result.is_ok());
         let list_devices = result.unwrap();
         assert_eq!(
             list_devices,
@@ -455,7 +454,6 @@ mod tests {
         let temp_path = temp_file.into_temp_path();
         let result = get_mount_device(Some(temp_path.as_ref()));
 
-        assert!(result.is_ok());
         let list_devices = result.unwrap();
         assert!(list_devices.is_empty());
     }
@@ -475,7 +473,6 @@ mod tests {
         let temp_path = temp_file.into_temp_path();
         let result = get_mount_device(Some(temp_path.as_ref()));
 
-        assert!(result.is_ok());
         let list_devices = result.unwrap();
         assert_eq!(
             list_devices,
@@ -494,7 +491,6 @@ mod tests {
         let temp_path = temp_file.into_temp_path();
         let result = get_mount_device(Some(temp_path.as_ref()));
 
-        assert!(result.is_ok());
         let list_devices = result.unwrap();
         assert!(list_devices.is_empty());
     }

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -82,14 +82,11 @@ const MTAB_PATH: &str = "/etc/mtab";
 // Get a mounted device with any filesystem for CDROM
 #[instrument]
 pub fn get_mount_device(path: Option<&Path>) -> Result<Vec<String>, Error> {
-    // Create a new FsTab instance and parse the mtab file
     let fstab = FsTab::new(path.unwrap_or(Path::new(MTAB_PATH)));
-
-    // Get the entries from the FsTab
     let entries: Vec<FsEntry> = fstab.get_entries()?;
 
-    // Filter and collect device names
-    let list_devices: Vec<String> = entries
+    // Retrieve the names of all devices that have cdrom-type filesystem (e.g., udf)
+    let cdrom_devices: Vec<String> = entries
         .into_iter()
         .filter_map(|entry| {
             if CDROM_VALID_FS.contains(&entry.vfs_type.as_str()) {
@@ -100,7 +97,7 @@ pub fn get_mount_device(path: Option<&Path>) -> Result<Vec<String>, Error> {
         })
         .collect();
 
-    Ok(list_devices)
+    Ok(cdrom_devices)
 }
 
 // Some zero-sized structs that just provide states for our state machine

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -18,7 +18,6 @@ use tracing;
 use crate::error::Error;
 use fstab::{FsEntry, FsTab};
 
-
 #[derive(Debug, Default, Deserialize, PartialEq, Clone)]
 pub struct Environment {
     #[serde(rename = "ProvisioningSection")]
@@ -79,7 +78,6 @@ pub const PATH_MOUNT_POINT: &str = "/run/azure-init/media/";
 const CDROM_VALID_FS: &[&str] = &["iso9660", "udf"];
 const MTAB_PATH: &str = "/etc/mtab";
 
-
 // Public wrapper function
 pub fn get_mount_device() -> Result<Vec<String>, Error> {
     wrapped_get_mount_device(Path::new(MTAB_PATH))
@@ -107,7 +105,6 @@ fn wrapped_get_mount_device(path: &Path) -> Result<Vec<String>, Error> {
 
     Ok(list_devices)
 }
-
 
 // Some zero-sized structs that just provide states for our state machine
 pub struct Mounted;
@@ -232,11 +229,10 @@ pub fn mount_parse_ovf_env(dev: String) -> Result<Environment, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::Error; 
+    use crate::error::Error;
     use fstab::FsEntry;
-    use std::path::PathBuf;
     use std::io;
-
+    use std::path::PathBuf;
 
     #[test]
     fn test_get_ovf_env_none_missing() {
@@ -448,16 +444,23 @@ mod tests {
         };
 
         // Use dependency injection for testing
-        let result = get_mount_device_with_mock(mock_path, mock_get_mounted_devices);
+        let result =
+            get_mount_device_with_mock(mock_path, mock_get_mounted_devices);
 
         // Assert
         assert!(result.is_ok());
         let list_devices = result.unwrap();
-        assert_eq!(list_devices, vec!["/dev/sr0".to_string(), "/dev/sr1".to_string()]);
+        assert_eq!(
+            list_devices,
+            vec!["/dev/sr0".to_string(), "/dev/sr1".to_string()]
+        );
     }
 
     // Helper function for testing
-    fn get_mount_device_with_mock<F>(path: &Path, get_devices: F) -> Result<Vec<String>, io::Error>
+    fn get_mount_device_with_mock<F>(
+        path: &Path,
+        get_devices: F,
+    ) -> Result<Vec<String>, io::Error>
     where
         F: Fn() -> Result<Vec<FsEntry>, io::Error>,
     {

--- a/libazureinit/src/media.rs
+++ b/libazureinit/src/media.rs
@@ -232,9 +232,7 @@ pub fn mount_parse_ovf_env(dev: String) -> Result<Environment, Error> {
 mod tests {
     use super::*;
     use crate::error::Error;
-    use fstab::FsEntry;
-    use std::io::{self, Write};
-    use std::path::PathBuf;
+    use std::io::Write;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use libazureinit::User;
 use libazureinit::{
     error::Error as LibError,
     goalstate, imds, media,
-    media::{Environment, get_mount_device},
+    media::{get_mount_device, Environment},
     reqwest::{header, Client},
     HostnameProvisioner, PasswordProvisioner, Provision, UserProvisioner,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,12 @@
 use std::process::ExitCode;
 
 use anyhow::Context;
-
 use libazureinit::imds::InstanceMetadata;
 use libazureinit::User;
 use libazureinit::{
     error::Error as LibError,
     goalstate, imds, media,
-    media::Environment,
+    media::{Environment, get_wrapped_mount_devices},
     reqwest::{header, Client},
     HostnameProvisioner, PasswordProvisioner, Provision, UserProvisioner,
 };
@@ -18,7 +17,7 @@ use libazureinit::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn get_environment() -> Result<Environment, anyhow::Error> {
-    let ovf_devices = media::get_mount_device()?;
+    let ovf_devices = get_wrapped_mount_devices()?;
     let mut environment: Option<Environment> = None;
 
     // loop until it finds a correct device.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use libazureinit::User;
 use libazureinit::{
     error::Error as LibError,
     goalstate, imds, media,
-    media::{Environment, get_wrapped_mount_devices},
+    media::{Environment, get_mount_device},
     reqwest::{header, Client},
     HostnameProvisioner, PasswordProvisioner, Provision, UserProvisioner,
 };
@@ -17,7 +17,7 @@ use libazureinit::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn get_environment() -> Result<Environment, anyhow::Error> {
-    let ovf_devices = get_wrapped_mount_devices()?;
+    let ovf_devices = get_mount_device()?;
     let mut environment: Option<Environment> = None;
 
     // loop until it finds a correct device.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use libazureinit::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn get_environment() -> Result<Environment, anyhow::Error> {
-    let ovf_devices = get_mount_device()?;
+    let ovf_devices = get_mount_device(None)?;
     let mut environment: Option<Environment> = None;
 
     // loop until it finds a correct device.


### PR DESCRIPTION
The while loop for get_mount_devices was stuck in a loop where it was  re-fetching the list of mounted devices every time if anything returned true and then would repeatedly find the same device. 

This should eliminate the issue and allow it to only add the device once.