### PR TITLE
Add a minimal tracing-subscriber configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ description = "A reference implementation for provisioning Linux VMs on Azure."
 exitcode = "1.1.2"
 anyhow = "1.0.81"
 tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing = "0.1.40"
 
 [dependencies.libazureinit]
 path = "libazureinit"


### PR DESCRIPTION
While debugging why running azure-init in a local VM hung forever, I added some minimal log configuration to figure out what was happening. Note that this only logs to stderr and is only configurable via the `AZURE_INIT_LOG` environment variable. The most minimal usage is like this:

AZURE_INIT_LOG=info azure-init

Which emits anything at info level or high. Refer to the tracing-subscriber documentation[0] for more complex examples.

Logs look like this:
```
2024-07-16T14:41:16.924909Z  INFO provision: azure_init: new
2024-07-16T14:41:16.928668Z  INFO provision:get_environment: azure_init: new
...
2024-07-16T14:41:17.065528Z  INFO provision:get_environment: azure_init: close time.busy=133ms time.idle=4.21ms
2024-07-16T14:41:17.073142Z  INFO provision:get_username: azure_init: new
2024-07-16T14:41:17.076323Z  INFO provision:get_username: azure_init: close time.busy=23.3µs time.idle=3.16ms
2024-07-16T14:41:17.081070Z  INFO provision: azure_init: close time.busy=153ms time.idle=3.12ms
```

It's configured to emit logs when a span opens and closes in addition to any explicit `tracing::{debug,info,warn,error}!` call, although we can disable that if folks don't like it. I also added spans to most of the library functions. All the spans are at the default `INFO` level and the default log configuration is to write logs for warning or higher, so running this without specifying `AZURE_INIT_LOG` results in the same behavior as before.

This doesn't try to integrate with OpenTelemetry or pipe logs to KVP; those are being wired up in #83.

[0] https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html#directives