### PR TITLE
Cargo: fix build issues around predicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ clap = { version = "<=4.4", features = ["derive", "cargo", "env"] }
 [dev-dependencies]
 # Purely for the MSRV requirement.
 assert_cmd = "<=2.0.13"
-predicates = "3"
+predicates = "<=3.1.0"
+predicates-core = "<=1.0.6"
+predicates-tree = "<=1.0.9"
 
 [dependencies.libazureinit]
 path = "libazureinit"


### PR DESCRIPTION
As `predicates` >=3.1.2, `predicates-core` >=1.0.8, `predicates-tree` >=1.0.11 require Rust 1.74 or newer, it is necessary to pin to older versions of crates like below, to avoid build issues when building with Rust 1.71.1.
