### PR TITLE
.github: ignore certain crates when bumping versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "assert_cmd"
+        # stay with <= 2.0.13 for Rust 1.71
+      - dependency-name: "clap"
+        # stay with <= 4.4 for Rust 1.71
+      - dependency-name: "predicates"
+        # stay with <= 3.1.0 for Rust 1.71
+      - dependency-name: "predicates-core"
+        # stay with <= 1.0.6 for Rust 1.71
+      - dependency-name: "predicates-tree"
+        # stay with <= 1.0.9 for Rust 1.71


### PR DESCRIPTION
For minimum supported Rust version, 1.71.1 at the moment, it is required to prevent certain packages from being updated by dependabot to recent versions. Add such dependencies to ignore list of dependabot.
