### PR TITLE
Use retry logic for HTTP communication with wireserver

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -23,8 +23,7 @@ fstab = "0.4.0"
 
 [dev-dependencies]
 tempfile = "3"
-# test-util feature is needed for time::advance in unit tests
-tokio = { version = "1", features = ["full", "test-util"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.11"
 whoami = "1"
 

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -25,6 +25,7 @@ fstab = "0.4.0"
 tempfile = "3"
 # test-util feature is needed for time::advance in unit tests
 tokio = { version = "1", features = ["full", "test-util"] }
+tokio-util = "0.7.11"
 whoami = "1"
 
 [lib]

--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -133,9 +133,7 @@ fn build_report_health_file(goalstate: Goalstate) -> String {
 mod tests {
     use super::{build_report_health_file, Goalstate};
 
-    #[test]
-    fn test_parsing_goalstate() {
-        let goalstate_str = "<Goalstate>
+    static GOALSTATE_STR: &str = "<Goalstate>
             <Container>
                 <ContainerId>2</ContainerId>
                 <RoleInstanceList>
@@ -147,7 +145,25 @@ mod tests {
             <Version>example_version</Version>
             <Incarnation>test_goal_incarnation</Incarnation>
         </Goalstate>";
-        let goalstate: Goalstate = serde_xml_rs::from_str(goalstate_str)
+
+    static HEALTH_STR: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
+        <Health xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n\
+            <GoalStateIncarnation>test_goal_incarnation</GoalStateIncarnation>\n\
+            <Container>\n\
+                <ContainerId>2</ContainerId>\n\
+                <RoleInstanceList>\n\
+                    <Role>\n\
+                        <InstanceId>test_user_instance_id</InstanceId>\n\
+                        <Health>\n\
+                            <State>Ready</State>\n\
+                        </Health>\n\
+                    </Role>\n\
+                </RoleInstanceList>\n\
+            </Container>\n\
+        </Health>";
+    #[test]
+    fn test_parsing_goalstate() {
+        let goalstate: Goalstate = serde_xml_rs::from_str(GOALSTATE_STR)
             .expect("Failed to parse the goalstate XML.");
         assert_eq!(goalstate.container.container_id, "2".to_owned());
         assert_eq!(
@@ -164,40 +180,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_report_health_file() {
-        let goalstate_str = "
-            <Goalstate>
-                <Container>
-                    <ContainerId>2</ContainerId>
-                    <RoleInstanceList>
-                        <RoleInstance>
-                            <InstanceId>test_user_instance_id</InstanceId>
-                        </RoleInstance>
-                    </RoleInstanceList>
-                </Container>
-                <Version>example_version</Version>
-                <Incarnation>test_goal_incarnation</Incarnation>
-            </Goalstate>";
-        let goalstate: Goalstate = serde_xml_rs::from_str(goalstate_str)
+        let goalstate: Goalstate = serde_xml_rs::from_str(GOALSTATE_STR)
             .expect("Failed to parse the goalstate XML.");
 
-        let expected_output =
-        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
-        <Health xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n\
-            <GoalStateIncarnation>test_goal_incarnation</GoalStateIncarnation>\n\
-            <Container>\n\
-                <ContainerId>2</ContainerId>\n\
-                <RoleInstanceList>\n\
-                    <Role>\n\
-                        <InstanceId>test_user_instance_id</InstanceId>\n\
-                        <Health>\n\
-                            <State>Ready</State>\n\
-                        </Health>\n\
-                    </Role>\n\
-                </RoleInstanceList>\n\
-            </Container>\n\
-        </Health>";
-
         let actual_output = build_report_health_file(goalstate);
-        assert_eq!(actual_output, expected_output);
+        assert_eq!(actual_output, HEALTH_STR);
     }
 }

--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -1,15 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use reqwest;
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
+
+use std::time::Duration;
 
 use serde::Deserialize;
 use serde_xml_rs::from_str;
 
+use tokio::time::timeout;
+
 use crate::error::Error;
+use crate::http;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Goalstate {
@@ -41,34 +45,80 @@ pub struct RoleInstance {
     instance_id: String,
 }
 
-pub async fn get_goalstate(client: &Client) -> Result<Goalstate, Error> {
-    let url = "http://168.63.129.16/machine/?comp=goalstate";
+const DEFAULT_GOALSTATE_URL: &str =
+    "http://168.63.129.16/machine/?comp=goalstate";
+
+pub async fn get_goalstate(
+    client: &Client,
+    retry_interval: Duration,
+    total_timeout: Duration,
+    url: Option<&str>,
+) -> Result<Goalstate, Error> {
+    let url = url.unwrap_or(DEFAULT_GOALSTATE_URL);
 
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
     headers.insert("x-ms-version", HeaderValue::from_static("2012-11-30"));
 
-    let request = client.get(url).headers(headers);
-    let response = request.send().await?;
+    let response = timeout(total_timeout, async {
+        let now = std::time::Instant::now();
+        loop {
+            if let Ok(response) = client
+                .get(url)
+                .headers(headers.clone())
+                .timeout(Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC))
+                .send()
+                .await
+            {
+                let statuscode = response.status();
 
-    if response.status().is_success() {
-        let body = response.text().await?;
+                if statuscode == StatusCode::OK {
+                    tracing::info!(
+                        "HTTP response succeeded with status {}",
+                        statuscode
+                    );
+                    return Ok(response);
+                }
 
-        let goalstate: Goalstate = from_str(&body)?;
-        Ok(goalstate)
-    } else {
-        Err(Error::HttpStatus {
-            endpoint: url.to_owned(),
-            status: response.status(),
-        })
-    }
+                if !http::RETRY_CODES.contains(&statuscode) {
+                    return response.error_for_status().map_err(|error| {
+                        tracing::error!(
+                            ?error,
+                            "{}",
+                            format!(
+                                "HTTP call failed due to status {}",
+                                statuscode
+                            )
+                        );
+                        error
+                    });
+                }
+            }
+
+            tracing::info!("Retrying to get HTTP response in {} sec, remaining timeout {} sec.", retry_interval.as_secs(), total_timeout.saturating_sub(now.elapsed()).as_secs());
+
+            tokio::time::sleep(retry_interval).await;
+        }
+    })
+    .await?;
+
+    let goalstate_body = response?.text().await?;
+
+    let goalstate: Goalstate = from_str(&goalstate_body)?;
+
+    Ok(goalstate)
 }
+
+const DEFAULT_HEALTH_URL: &str = "http://168.63.129.16/machine/?comp=health";
 
 pub async fn report_health(
     client: &Client,
     goalstate: Goalstate,
+    retry_interval: Duration,
+    total_timeout: Duration,
+    url: Option<&str>,
 ) -> Result<(), Error> {
-    let url = "http://168.63.129.16/machine/?comp=health";
+    let url = url.unwrap_or(DEFAULT_HEALTH_URL);
 
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
@@ -80,21 +130,40 @@ pub async fn report_health(
 
     let post_request = build_report_health_file(goalstate);
 
-    let response = client
-        .post(url)
-        .headers(headers)
-        .body(post_request)
-        .send()
-        .await?;
+    _ = timeout(total_timeout, async {
+        let now = std::time::Instant::now();
+        loop {
+            if let Ok(response) = client
+                .post(url)
+                .headers(headers.clone())
+                .body(post_request.clone())
+                .timeout(Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC))
+                .send()
+                .await
+            {
+                let statuscode = response.status();
 
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        Err(Error::HttpStatus {
-            endpoint: url.to_owned(),
-            status: response.status(),
-        })
-    }
+                if statuscode == StatusCode::OK {
+                    tracing::info!("HTTP response succeeded with status {}", statuscode);
+                    return Ok(response);
+                }
+
+                if !http::RETRY_CODES.contains(&statuscode) {
+                    return response.error_for_status().map_err(|error| {
+                        tracing::error!(?error, "{}", format!("HTTP call failed due to status {}", statuscode));
+                        error
+                    });
+                }
+            }
+
+            tracing::info!("Retrying to get HTTP response in {} sec, remaining timeout {} sec.", retry_interval.as_secs(), total_timeout.saturating_sub(now.elapsed()).as_secs());
+
+            tokio::time::sleep(retry_interval).await;
+        }
+    })
+    .await?;
+
+    Ok(())
 }
 
 fn build_report_health_file(goalstate: Goalstate) -> String {
@@ -131,7 +200,15 @@ fn build_report_health_file(goalstate: Goalstate) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_report_health_file, Goalstate};
+    use super::{
+        build_report_health_file, get_goalstate, report_health, Goalstate,
+    };
+
+    use reqwest::{header, Client, StatusCode};
+    use std::time::Duration;
+    use tokio::net::TcpListener;
+
+    use crate::{http, unittest};
 
     static GOALSTATE_STR: &str = "<Goalstate>
             <Container>
@@ -185,5 +262,112 @@ mod tests {
 
         let actual_output = build_report_health_file(goalstate);
         assert_eq!(actual_output, HEALTH_STR);
+    }
+
+    // Runs a test around sending via get_goalstate() with a given statuscode.
+    async fn run_goalstate_retry(statuscode: &StatusCode) -> bool {
+        const HTTP_TOTAL_TIMEOUT_SEC: u64 = 5;
+        const HTTP_PERCLIENT_TIMEOUT_SEC: u64 = 5;
+        const HTTP_RETRY_INTERVAL_SEC: u64 = 1;
+
+        let mut default_headers = header::HeaderMap::new();
+        let user_agent =
+            header::HeaderValue::from_str("azure-init test").unwrap();
+
+        // Run local test servers for goalstate and health that reply with simple test data.
+        let gs_ok_payload =
+            unittest::get_http_response_payload(statuscode, GOALSTATE_STR);
+        let gs_serverlistener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let gs_addr = gs_serverlistener.local_addr().unwrap();
+
+        let health_ok_payload =
+            unittest::get_http_response_payload(statuscode, HEALTH_STR);
+        let health_serverlistener =
+            TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let health_addr = health_serverlistener.local_addr().unwrap();
+
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+
+        let gs_server = tokio::spawn(unittest::serve_requests(
+            gs_serverlistener,
+            gs_ok_payload,
+            cancel_token.clone(),
+        ));
+        let health_server = tokio::spawn(unittest::serve_requests(
+            health_serverlistener,
+            health_ok_payload,
+            cancel_token.clone(),
+        ));
+
+        default_headers.insert(header::USER_AGENT, user_agent);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(HTTP_PERCLIENT_TIMEOUT_SEC))
+            .default_headers(default_headers)
+            .build()
+            .unwrap();
+
+        let vm_goalstate = get_goalstate(
+            &client,
+            Duration::from_secs(HTTP_RETRY_INTERVAL_SEC),
+            Duration::from_secs(HTTP_TOTAL_TIMEOUT_SEC),
+            Some(
+                format!("http://{:}:{:}/", gs_addr.ip(), gs_addr.port())
+                    .as_str(),
+            ),
+        )
+        .await;
+
+        if !vm_goalstate.is_ok() {
+            cancel_token.cancel();
+
+            let gs_requests = gs_server.await.unwrap();
+            let health_requests = health_server.await.unwrap();
+
+            if http::HARDFAIL_CODES.contains(statuscode) {
+                assert_eq!(gs_requests, 1);
+                assert_eq!(health_requests, 0);
+            }
+
+            if http::RETRY_CODES.contains(statuscode) {
+                assert!(gs_requests >= 4);
+                assert_eq!(health_requests, 0);
+            }
+
+            return false;
+        }
+
+        let res_health = report_health(
+            &client,
+            vm_goalstate.unwrap(),
+            Duration::from_secs(HTTP_RETRY_INTERVAL_SEC),
+            Duration::from_secs(HTTP_TOTAL_TIMEOUT_SEC),
+            Some(
+                format!(
+                    "http://{:}:{:}/",
+                    health_addr.ip(),
+                    health_addr.port()
+                )
+                .as_str(),
+            ),
+        )
+        .await;
+
+        res_health.is_ok()
+    }
+
+    #[tokio::test]
+    async fn goalstate_query_retry() {
+        // status codes that should succeed.
+        assert!(run_goalstate_retry(&StatusCode::OK).await);
+
+        // status codes that should be retried up to 5 minutes.
+        for rc in http::RETRY_CODES {
+            assert!(!run_goalstate_retry(rc).await);
+        }
+
+        // status codes that should result into immediate failures.
+        for rc in http::HARDFAIL_CODES {
+            assert!(!run_goalstate_retry(rc).await);
+        }
     }
 }

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -22,3 +22,5 @@ pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
     StatusCode::FORBIDDEN,
     StatusCode::METHOD_NOT_ALLOWED,
 ];
+
+pub(crate) const IMDS_HTTP_TIMEOUT_SEC: u64 = 30;

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -24,3 +24,4 @@ pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
 ];
 
 pub(crate) const IMDS_HTTP_TIMEOUT_SEC: u64 = 30;
+pub(crate) const WIRESERVER_HTTP_TIMEOUT_SEC: u64 = 30;

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use reqwest::StatusCode;
+
+/// Set of StatusCodes that should be retried,
+/// e.g. 400, 404, 410, 429, 500, 503.
+pub(crate) const RETRY_CODES: &[StatusCode] = &[
+    StatusCode::BAD_REQUEST,
+    StatusCode::NOT_FOUND,
+    StatusCode::GONE,
+    StatusCode::TOO_MANY_REQUESTS,
+    StatusCode::INTERNAL_SERVER_ERROR,
+    StatusCode::SERVICE_UNAVAILABLE,
+];
+
+/// Set of StatusCodes that should immediately fail,
+/// e.g. 401, 403, 405.
+#[allow(dead_code)]
+pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
+    StatusCode::UNAUTHORIZED,
+    StatusCode::FORBIDDEN,
+    StatusCode::METHOD_NOT_ALLOWED,
+];

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -110,7 +110,7 @@ pub async fn query(
             if let Ok(response) = client
                 .get(url)
                 .headers(headers.clone())
-                .timeout(Duration::from_secs(30))
+                .timeout(Duration::from_secs(http::IMDS_HTTP_TIMEOUT_SEC))
                 .send()
                 .await
             {

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -91,21 +91,17 @@ where
     }
 }
 
-static DEFAULT_IMDS_URL: &str =
+const DEFAULT_IMDS_URL: &str =
     "http://169.254.169.254/metadata/instance?api-version=2021-02-01";
 
 pub async fn query(
     client: &Client,
     retry_interval: Duration,
     total_timeout: Duration,
-    input_url: Option<&str>,
+    url: Option<&str>,
 ) -> Result<InstanceMetadata, Error> {
     let mut headers = HeaderMap::new();
-
-    let url = match input_url {
-        Some(url) => url,
-        None => DEFAULT_IMDS_URL,
-    };
+    let url = url.unwrap_or(DEFAULT_IMDS_URL);
 
     headers.insert("Metadata", HeaderValue::from_static("true"));
 
@@ -121,7 +117,7 @@ pub async fn query(
                 let statuscode = response.status();
 
                 if statuscode.is_success() && statuscode == StatusCode::OK {
-                    return response.error_for_status();
+                    return Ok(response);
                 }
 
                 if !http::RETRY_CODES.contains(&statuscode) {

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -123,6 +123,7 @@ pub async fn query(
         loop {
             if let Ok(response) = client
                 .get(url)
+                .headers(headers.clone())
                 .timeout(Duration::from_secs(30))
                 .send()
                 .await

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod error;
 pub mod goalstate;
+pub(crate) mod http;
 pub mod imds;
 pub mod media;
 

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -15,5 +15,8 @@ pub use provision::{
     Provision,
 };
 
+#[cfg(test)]
+mod unittest;
+
 // Re-export as the Client is used in our API.
 pub use reqwest;

--- a/libazureinit/src/unittest.rs
+++ b/libazureinit/src/unittest.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use reqwest::StatusCode;
+
+// Returns expected HTTP response for the given status code and body string.
+pub(crate) fn get_http_response_payload(
+    statuscode: &StatusCode,
+    body_str: &str,
+) -> String {
+    // Reply message includes the whole body in case of OK, otherwise empty data.
+    let res = match statuscode {
+            &StatusCode::OK => format!("HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}", statuscode.as_u16(), statuscode.to_string(), body_str.len(), body_str.to_string()),
+            _ => {
+                format!("HTTP/1.1 {} {}\r\n\r\n", statuscode.as_u16(), statuscode.to_string())
+            }
+        };
+
+    res
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,12 +177,24 @@ async fn provision() -> Result<(), anyhow::Error> {
         ])
         .provision()?;
 
-    let vm_goalstate = goalstate::get_goalstate(&client)
-        .await
-        .with_context(|| "Failed to get desired goalstate.")?;
-    goalstate::report_health(&client, vm_goalstate)
-        .await
-        .with_context(|| "Failed to report VM health.")?;
+    let vm_goalstate = goalstate::get_goalstate(
+        &client,
+        Duration::from_secs(imds_http_retry_interval_sec),
+        Duration::from_secs(imds_http_timeout_sec),
+        None, // default wireserver goalstate URL
+    )
+    .await
+    .with_context(|| "Failed to get desired goalstate.")?;
+
+    goalstate::report_health(
+        &client,
+        vm_goalstate,
+        Duration::from_secs(imds_http_retry_interval_sec),
+        Duration::from_secs(imds_http_timeout_sec),
+        None, // default wireserver health URL
+    )
+    .await
+    .with_context(|| "Failed to report VM health.")?;
 
     Ok(())
 }


### PR DESCRIPTION
Use similar retry logic for wireserver communication, like done for IMDS.
Add unit tests for `get_goalstate` and `report_health`.

Split `RETRY_CODES` and `HARDFAIL_CODES` into a separate module `http`, so that those can be used by other parts of libazureinit.

Add back missing headers into `client.get()` in libazureinit IMDS.

Fixes https://github.com/Azure/azure-init/issues/63.

## Testing done

Unit tests pass.