### PR TITLE
Retrieve correct authorizedkeysfile path

### DIFF
--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -3,11 +3,13 @@
 
 use std::{
     fs::Permissions,
-    io::Write,
+    io::{self, Write},
     os::unix::fs::{DirBuilderExt, PermissionsExt},
+    path::PathBuf,
+    process::Command,
 };
 
-use tracing::instrument;
+use tracing::{info, instrument};
 
 use crate::error::Error;
 use crate::imds::PublicKeys;
@@ -27,7 +29,11 @@ pub(crate) fn provision_ssh(
     // the permissions are correct.
     std::fs::set_permissions(&ssh_dir, Permissions::from_mode(0o700))?;
 
-    let authorized_keys_path = ssh_dir.join("authorized_keys");
+    let authorized_keys_path = match get_authorized_keys_path_from_sshd()? {
+        Some(path) => user.dir.join(path),
+        None => user.dir.join(".ssh/authorized_keys"),
+    };
+    info!("Using authorized_keys path: {:?}", authorized_keys_path);
     let mut authorized_keys = std::fs::File::create(&authorized_keys_path)?;
     authorized_keys.set_permissions(Permissions::from_mode(0o600))?;
     keys.iter()
@@ -37,16 +43,111 @@ pub(crate) fn provision_ssh(
     Ok(())
 }
 
+pub(crate) fn get_authorized_keys_path_from_sshd() -> io::Result<Option<PathBuf>>
+{
+    let sshd_output = Command::new("sshd").arg("-T").output()?;
+    if !sshd_output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("sshd -T failed with status: {}", sshd_output.status),
+        ));
+    }
+
+    let stdout = sshd_output.stdout;
+    let sshd_output = String::from_utf8_lossy(&stdout);
+    for line in sshd_output.lines() {
+        if line.starts_with("authorizedkeysfile") {
+            let keypath: Vec<&str> = line.split_whitespace().collect();
+            if keypath.len() > 1 {
+                info!("Found authorized_keys path: {}", keypath[1]);
+                return Ok(Some(PathBuf::from(keypath[1])));
+            }
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
 
-    use super::provision_ssh;
+    use nix::unistd::User;
+    use tracing::info;
+
     use crate::imds::PublicKeys;
     use std::{
         fs::Permissions,
-        io::Read,
+        io::{self, Read, Write},
         os::unix::fs::{DirBuilderExt, PermissionsExt},
+        path::PathBuf,
+        process::Command,
     };
+
+    fn mock_sshd_output(output: &str) -> io::Result<Option<PathBuf>> {
+        let output = Command::new("echo").arg(output).output()?;
+        if !output.status.success() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Failed to execute mock sshd -T",
+            ));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if line.starts_with("authorizedkeysfile") {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() > 1 {
+                    info!("Found authorized_keys path: {:?}", parts[1]);
+                    return Ok(Some(PathBuf::from(parts[1])));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn mock_provision_ssh(user: &User, keys: &[PublicKeys]) -> io::Result<()> {
+        let ssh_dir = user.dir.join(".ssh");
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&ssh_dir)?;
+        nix::unistd::chown(&ssh_dir, Some(user.uid), Some(user.gid))?;
+        std::fs::set_permissions(&ssh_dir, Permissions::from_mode(0o700))?;
+
+        let output = "authorizedkeysfile .ssh/authorized_keys";
+        let authorized_keys_path = match mock_sshd_output(output)? {
+            Some(path) => user.dir.join(path),
+            None => user.dir.join(".ssh/authorized_keys"),
+        };
+        info!("Using authorized_keys path: {:?}", authorized_keys_path);
+
+        let mut authorized_keys = std::fs::File::create(&authorized_keys_path)?;
+        authorized_keys.set_permissions(Permissions::from_mode(0o600))?;
+        keys.iter().try_for_each(|key| {
+            writeln!(authorized_keys, "{}", key.key_data)
+        })?;
+        nix::unistd::chown(
+            &authorized_keys_path,
+            Some(user.uid),
+            Some(user.gid),
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_authorized_keys_path_from_sshd_present() {
+        let output = "authorizedkeysfile /custom/path/authorized_keys";
+        let path = mock_sshd_output(output).unwrap();
+        assert_eq!(path, Some(PathBuf::from("/custom/path/authorized_keys")));
+    }
+
+    #[test]
+    fn test_get_authorized_keys_path_from_sshd_absent() {
+        let output = "someotherconfig value";
+        let path = mock_sshd_output(output).unwrap();
+        assert_eq!(path, None);
+    }
 
     // Test that we set the permission bits correctly on the ssh files; sadly it's difficult to test
     // chown without elevated permissions.
@@ -69,7 +170,8 @@ mod tests {
                 path: "unused".to_string(),
             },
         ];
-        provision_ssh(&user, &keys).unwrap();
+
+        mock_provision_ssh(&user, &keys).unwrap();
 
         let ssh_dir =
             std::fs::File::open(home_dir.path().join(".ssh")).unwrap();
@@ -116,7 +218,8 @@ mod tests {
                 path: "unused".to_string(),
             },
         ];
-        provision_ssh(&user, &keys).unwrap();
+
+        mock_provision_ssh(&user, &keys).unwrap();
 
         let ssh_dir =
             std::fs::File::open(home_dir.path().join(".ssh")).unwrap();
@@ -150,8 +253,9 @@ mod tests {
                 path: "unused".to_string(),
             },
         ];
-        provision_ssh(&user, &keys[..1]).unwrap();
-        provision_ssh(&user, &keys[1..]).unwrap();
+
+        mock_provision_ssh(&user, &keys[..1]).unwrap();
+        mock_provision_ssh(&user, &keys[1..]).unwrap();
 
         let mut auth_file =
             std::fs::File::open(home_dir.path().join(".ssh/authorized_keys"))


### PR DESCRIPTION
By default azure-init assumes the authorized keys file is $HOME/.ssh/authorized_keys, this function retrieves informartion from sshd config using sshd -G. If there exists no information it will return None. Fixes #97.

<!-- [ Describe the change in 1 - 3 paragraphs ] -->

## How to use

<!-- [ Describe what reviewers need to do in order to validate this PR ] -->

## Testing done

<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
