### PR TITLE
libazureinit: rustdocs for error, http, goalstate, IMDS, unittest

### DIFF
--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -1,6 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/// Set of error codes that can be used by libazureinit.
+///
+/// # Example
+///
+/// ```rust
+/// # use libazureinit::error::Error;
+/// # use std::process::Command;
+///
+/// fn run_ls() -> Result<(), Error> {
+///     let ls_status = Command::new("ls").arg("/tmp").status().unwrap();
+///     if !ls_status.success() {
+///         Err(Error::SubprocessFailed {
+///             command: "ls".to_string(),
+///             status: ls_status,
+///         })
+///     } else {
+///         Ok(())
+///     }
+/// }
+///
+/// ```
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Unable to deserialize or serialize JSON data")]

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -5,6 +5,15 @@ use reqwest::StatusCode;
 
 /// Set of StatusCodes that should be retried,
 /// e.g. 400, 404, 410, 429, 500, 503.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use libazureinit::http::RETRY_CODES;
+/// # use reqwest::StatusCode;
+///
+/// assert!(RETRY_CODES.contains(StatusCode::NOT_FOUND));
+/// ```
 pub(crate) const RETRY_CODES: &[StatusCode] = &[
     StatusCode::BAD_REQUEST,
     StatusCode::NOT_FOUND,
@@ -16,6 +25,15 @@ pub(crate) const RETRY_CODES: &[StatusCode] = &[
 
 /// Set of StatusCodes that should immediately fail,
 /// e.g. 401, 403, 405.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use libazureinit::http::HARDFAIL_CODES;
+/// # use reqwest::StatusCode;
+///
+/// assert!(HARDFAIL_CODES.contains(StatusCode::FORBIDDEN));
+/// ```
 #[allow(dead_code)]
 pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
     StatusCode::UNAUTHORIZED,
@@ -23,5 +41,7 @@ pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
     StatusCode::METHOD_NOT_ALLOWED,
 ];
 
+/// Timeout for communicating with IMDS.
 pub(crate) const IMDS_HTTP_TIMEOUT_SEC: u64 = 30;
+/// Timeout for communicating with wireserver for goalstate, health.
 pub(crate) const WIRESERVER_HTTP_TIMEOUT_SEC: u64 = 30;

--- a/libazureinit/src/unittest.rs
+++ b/libazureinit/src/unittest.rs
@@ -6,7 +6,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-// Returns expected HTTP response for the given status code and body string.
+/// Returns expected HTTP response for the given status code and body string.
 pub(crate) fn get_http_response_payload(
     statuscode: &StatusCode,
     body_str: &str,
@@ -22,8 +22,8 @@ pub(crate) fn get_http_response_payload(
     res
 }
 
-// Accept incoming connections until the cancellation token is used, then return the count
-// of accepted connections.
+/// Accept incoming connections until the cancellation token is used, then return the count
+/// of accepted connections.
 pub(crate) async fn serve_requests(
     listener: TcpListener,
     payload: String,


### PR DESCRIPTION
Add rustdocs for error, http, goalstate, IMDS, unittest with examples if possible.

See also https://github.com/Azure/azure-init/issues/127.

## Testing done

Rustdocs can be checked via web like:
```
$ cargo doc --open
```

Rustdocs tests passed.

```
$ cargo test --doc
```