### PR TITLE
Refactor the HTTP retry code to use a single implementation

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -22,6 +22,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 fstab = "0.4.0"
 
 [dev-dependencies]
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.11"

--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -24,13 +24,13 @@
 /// ```
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Unable to deserialize or serialize JSON data")]
+    #[error("Unable to deserialize or serialize JSON data: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("Unable to deserialize or serialize XML data")]
+    #[error("Unable to deserialize or serialize XML data: {0}")]
     Xml(#[from] serde_xml_rs::Error),
-    #[error("HTTP client error ocurred")]
+    #[error("HTTP client error occurred: {0}")]
     Http(#[from] reqwest::Error),
-    #[error("An I/O error occurred")]
+    #[error("An I/O error occurred: {0}")]
     Io(#[from] std::io::Error),
     #[error("HTTP request did not succeed (HTTP {status} from {endpoint})")]
     HttpStatus {
@@ -44,7 +44,7 @@ pub enum Error {
     },
     #[error("failed to construct a C-style string")]
     NulError(#[from] std::ffi::NulError),
-    #[error("nix call failed")]
+    #[error("nix call failed: {0}")]
     Nix(#[from] nix::Error),
     #[error("The user {user} does not exist")]
     UserMissing { user: String },
@@ -54,7 +54,7 @@ pub enum Error {
     InstanceMetadataFailure,
     #[error("Provisioning a user with a non-empty password is not supported")]
     NonEmptyPassword,
-    #[error("Unable to get list of block devices")]
+    #[error("Unable to get list of block devices: {0}")]
     BlockUtils(#[from] block_utils::BlockUtilsError),
     #[error(
         "Failed to set the hostname; none of the provided backends succeeded"

--- a/libazureinit/src/error.rs
+++ b/libazureinit/src/error.rs
@@ -69,5 +69,11 @@ pub enum Error {
     )]
     NoPasswordProvisioner,
     #[error("A timeout error occurred")]
-    Timeout(#[from] tokio::time::error::Elapsed),
+    Timeout,
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        Self::Timeout
+    }
 }

--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -3,14 +3,12 @@
 
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 
 use std::time::Duration;
 
 use serde::Deserialize;
 use serde_xml_rs::from_str;
-
-use tokio::time::timeout;
 
 use crate::error::Error;
 use crate::http;
@@ -112,50 +110,17 @@ pub async fn get_goalstate(
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
     headers.insert("x-ms-version", HeaderValue::from_static("2012-11-30"));
-
-    let response = timeout(total_timeout, async {
-        let now = std::time::Instant::now();
-        loop {
-            if let Ok(response) = client
-                .get(url)
-                .headers(headers.clone())
-                .timeout(Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC))
-                .send()
-                .await
-            {
-                let statuscode = response.status();
-
-                if statuscode == StatusCode::OK {
-                    tracing::info!(
-                        "HTTP response succeeded with status {}",
-                        statuscode
-                    );
-                    return Ok(response);
-                }
-
-                if !http::RETRY_CODES.contains(&statuscode) {
-                    return response.error_for_status().map_err(|error| {
-                        tracing::error!(
-                            ?error,
-                            "{}",
-                            format!(
-                                "HTTP call failed due to status {}",
-                                statuscode
-                            )
-                        );
-                        error
-                    });
-                }
-            }
-
-            tracing::info!("Retrying to get HTTP response in {} sec, remaining timeout {} sec.", retry_interval.as_secs(), total_timeout.saturating_sub(now.elapsed()).as_secs());
-
-            tokio::time::sleep(retry_interval).await;
-        }
-    })
+    let (response, _) = http::get(
+        client,
+        headers,
+        Duration::from_secs(http::IMDS_HTTP_TIMEOUT_SEC),
+        retry_interval,
+        total_timeout,
+        url,
+    )
     .await?;
 
-    let goalstate_body = response?.text().await?;
+    let goalstate_body = response.text().await?;
 
     let goalstate: Goalstate = from_str(&goalstate_body)?;
 
@@ -215,40 +180,20 @@ pub async fn report_health(
         "Content-Type",
         HeaderValue::from_static("text/xml;charset=utf-8"),
     );
+    let request_timeout =
+        Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC);
 
     let post_request = build_report_health_file(goalstate);
 
-    _ = timeout(total_timeout, async {
-        let now = std::time::Instant::now();
-        loop {
-            if let Ok(response) = client
-                .post(url)
-                .headers(headers.clone())
-                .body(post_request.clone())
-                .timeout(Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC))
-                .send()
-                .await
-            {
-                let statuscode = response.status();
-
-                if statuscode == StatusCode::OK {
-                    tracing::info!("HTTP response succeeded with status {}", statuscode);
-                    return Ok(response);
-                }
-
-                if !http::RETRY_CODES.contains(&statuscode) {
-                    return response.error_for_status().map_err(|error| {
-                        tracing::error!(?error, "{}", format!("HTTP call failed due to status {}", statuscode));
-                        error
-                    });
-                }
-            }
-
-            tracing::info!("Retrying to get HTTP response in {} sec, remaining timeout {} sec.", retry_interval.as_secs(), total_timeout.saturating_sub(now.elapsed()).as_secs());
-
-            tokio::time::sleep(retry_interval).await;
-        }
-    })
+    _ = http::post(
+        client,
+        headers,
+        post_request,
+        request_timeout,
+        retry_interval,
+        total_timeout,
+        url,
+    )
     .await?;
 
     Ok(())

--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -4,6 +4,7 @@
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderValue;
 use reqwest::Client;
+use tracing::instrument;
 
 use std::time::Duration;
 
@@ -99,32 +100,52 @@ const DEFAULT_GOALSTATE_URL: &str =
 ///     Some("http://127.0.0.1:8000/"),
 /// );
 /// ```
+#[instrument(err, skip_all)]
 pub async fn get_goalstate(
     client: &Client,
     retry_interval: Duration,
-    total_timeout: Duration,
+    mut total_timeout: Duration,
     url: Option<&str>,
 ) -> Result<Goalstate, Error> {
-    let url = url.unwrap_or(DEFAULT_GOALSTATE_URL);
-
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
     headers.insert("x-ms-version", HeaderValue::from_static("2012-11-30"));
-    let (response, _) = http::get(
-        client,
-        headers,
-        Duration::from_secs(http::IMDS_HTTP_TIMEOUT_SEC),
-        retry_interval,
-        total_timeout,
-        url,
-    )
-    .await?;
+    let url = url.unwrap_or(DEFAULT_GOALSTATE_URL);
+    let request_timeout =
+        Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC);
 
-    let goalstate_body = response.text().await?;
+    while !total_timeout.is_zero() {
+        let (response, remaining_timeout) = http::get(
+            client,
+            headers.clone(),
+            request_timeout,
+            retry_interval,
+            total_timeout,
+            url,
+        )
+        .await?;
+        match response.text().await {
+            Ok(body) => {
+                let goalstate = from_str(&body).map_err(|error| {
+                    tracing::warn!(
+                        ?error,
+                        "The response body was invalid and could not be deserialized"
+                    );
+                    error.into()
+                });
+                if goalstate.is_ok() {
+                    return goalstate;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Failed to read the full response body")
+            }
+        }
 
-    let goalstate: Goalstate = from_str(&goalstate_body)?;
+        total_timeout = remaining_timeout;
+    }
 
-    Ok(goalstate)
+    Err(Error::Timeout)
 }
 
 const DEFAULT_HEALTH_URL: &str = "http://168.63.129.16/machine/?comp=health";
@@ -164,6 +185,7 @@ const DEFAULT_HEALTH_URL: &str = "http://168.63.129.16/machine/?comp=health";
 ///     );
 /// }
 /// ```
+#[instrument(err, skip_all)]
 pub async fn report_health(
     client: &Client,
     goalstate: Goalstate,
@@ -171,8 +193,6 @@ pub async fn report_health(
     total_timeout: Duration,
     url: Option<&str>,
 ) -> Result<(), Error> {
-    let url = url.unwrap_or(DEFAULT_HEALTH_URL);
-
     let mut headers = HeaderMap::new();
     headers.insert("x-ms-agent-name", HeaderValue::from_static("azure-init"));
     headers.insert("x-ms-version", HeaderValue::from_static("2012-11-30"));
@@ -182,6 +202,7 @@ pub async fn report_health(
     );
     let request_timeout =
         Duration::from_secs(http::WIRESERVER_HTTP_TIMEOUT_SEC);
+    let url = url.unwrap_or(DEFAULT_HEALTH_URL);
 
     let post_request = build_report_health_file(goalstate);
 
@@ -402,5 +423,55 @@ mod tests {
         for rc in http::HARDFAIL_CODES {
             assert!(!run_goalstate_retry(rc).await);
         }
+    }
+
+    // Assert malformed responses are retried.
+    //
+    // In this case the server doesn't return XML at all.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn malformed_response() {
+        let body = "You thought this was XML, but you were wrong";
+        let payload = format!(
+            "HTTP/1.1 {} {}\r\nContent-Type: application/xml\r\nContent-Length: {}\r\n\r\n{}",
+             StatusCode::OK.as_u16(),
+             StatusCode::OK.to_string(),
+             body.len(),
+             body
+        );
+
+        let serverlistener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = serverlistener.local_addr().unwrap();
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let server = tokio::spawn(unittest::serve_requests(
+            serverlistener,
+            payload,
+            cancel_token.clone(),
+        ));
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let res = get_goalstate(
+            &client,
+            Duration::from_millis(10),
+            Duration::from_millis(50),
+            Some(format!("http://{:}:{:}/", addr.ip(), addr.port()).as_str()),
+        )
+        .await;
+
+        cancel_token.cancel();
+
+        let requests = server.await.unwrap();
+        assert!(requests >= 2);
+        assert!(logs_contain(
+            "The response body was invalid and could not be deserialized"
+        ));
+        match res {
+            Err(crate::error::Error::Timeout) => {}
+            _ => panic!("Response should have timed out"),
+        };
     }
 }

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use reqwest::StatusCode;
+use std::time::Duration;
+
+use reqwest::{header::HeaderMap, Client, Request, StatusCode};
+use tokio::time::timeout;
+use tracing::{instrument, Instrument};
+
+use crate::error::Error;
 
 /// Set of StatusCodes that should be retried,
 /// e.g. 400, 404, 410, 429, 500, 503.
@@ -45,3 +51,300 @@ pub(crate) const HARDFAIL_CODES: &[StatusCode] = &[
 pub(crate) const IMDS_HTTP_TIMEOUT_SEC: u64 = 30;
 /// Timeout for communicating with wireserver for goalstate, health.
 pub(crate) const WIRESERVER_HTTP_TIMEOUT_SEC: u64 = 30;
+
+/// Send an HTTP GET request to the given URL with an empty body.
+#[instrument(err, skip_all)]
+pub(crate) async fn get(
+    client: &Client,
+    headers: HeaderMap,
+    request_timeout: Duration,
+    retry_interval: Duration,
+    retry_for: Duration,
+    url: &str,
+) -> Result<(reqwest::Response, Duration), Error> {
+    let req = client
+        .get(url)
+        .headers(headers)
+        .timeout(request_timeout)
+        .build()?;
+    request(client, req, retry_interval, retry_for).await
+}
+
+/// Send an HTTP GET request to the given URL with an empty body.
+///
+/// `body` must implement Clone as retries must clone the entire request.
+#[instrument(err, skip_all)]
+pub(crate) async fn post<T: Into<reqwest::Body> + Clone>(
+    client: &Client,
+    headers: HeaderMap,
+    body: T,
+    request_timeout: Duration,
+    retry_interval: Duration,
+    retry_for: Duration,
+    url: &str,
+) -> Result<(reqwest::Response, Duration), Error> {
+    let req = client
+        .post(url)
+        .headers(headers)
+        .body(body)
+        .timeout(request_timeout)
+        .build()?;
+    request(client, req, retry_interval, retry_for).await
+}
+
+/// Retry an HTTP request until it returns HTTP 200 or the timeout is reached.
+///
+/// In the event that the request succeeds, the total remaining timeout is returned with the response.
+/// This can be used to resume retrying in the event that the body is malformed.
+///
+/// # Panics
+///
+/// This function will panic if the request passed cannot be cloned (i.e. the body is a Stream).
+/// Functions wrapping this must ensure to include an additional bound on `Body` (see [`post`]).
+async fn request(
+    client: &Client,
+    request: Request,
+    retry_interval: Duration,
+    retry_for: Duration,
+) -> Result<(reqwest::Response, Duration), Error> {
+    timeout(retry_for, async {
+        let now = std::time::Instant::now();
+        let mut attempt =  0_u32;
+        loop {
+            let span = tracing::info_span!("request", attempt, http_status = tracing::field::Empty);
+            let req = request.try_clone().expect("The request body MUST be clone-able");
+            match client
+                .execute(req)
+                .instrument(span.clone())
+                .await {
+                    Ok(response) => {
+                        let _enter = span.enter();
+                        let statuscode = response.status();
+                        span.record("http_status", statuscode.as_u16());
+                        tracing::info!(url=response.url().as_str(), "HTTP response received");
+
+                        match response.error_for_status() {
+                            Ok(response) => {
+                                if statuscode == StatusCode::OK {
+                                    tracing::info!("HTTP response succeeded with status {}", statuscode);
+                                    return Ok((response, retry_for.saturating_sub(now.elapsed() + retry_interval)));
+                                }
+                            },
+                            Err(error) => {
+                                if !RETRY_CODES.contains(&statuscode) {
+                                    tracing::error!(
+                                        ?error,
+                                        "HTTP response status code is fatal and the request will not be retried",
+                                    );
+                                    return Err(error.into());
+                                }
+                            },
+                        }
+
+                    },
+                    Err(error) => {
+                        let _enter = span.enter();
+                        tracing::error!(?error, "HTTP request failed to complete");
+                    },
+                }
+            span.in_scope(||{
+                tracing::warn!(
+                    "Failed to get a successful HTTP response, retrying in {} sec, remaining timeout {} sec.",
+                    retry_interval.as_secs(),
+                    retry_for.saturating_sub(now.elapsed()).as_secs()
+                );
+            });
+            // Explicitly dropping here to ensure the sleep isn't included in the request timings
+            drop(span);
+
+            attempt += 1;
+            tokio::time::sleep(retry_interval).await;
+        }
+    }).await?
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use reqwest::{header, Client, StatusCode};
+    use std::time::Duration;
+    use tokio::{io::AsyncWriteExt, net::TcpListener};
+
+    use crate::unittest::{get_http_response_payload, serve_requests};
+
+    const BODY_CONTENTS: &str = "hello world";
+
+    // Helper that returns how many attempts were made on a given HTTP status code.
+    async fn serve_valid_http_with(
+        statuscode: &StatusCode,
+        body: &str,
+    ) -> bool {
+        let serverlistener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = serverlistener.local_addr().unwrap();
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let server = tokio::spawn(serve_requests(
+            serverlistener,
+            get_http_response_payload(statuscode, body),
+            cancel_token.clone(),
+        ));
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .unwrap();
+
+        let res = super::get(
+            &client,
+            header::HeaderMap::new(),
+            Duration::from_millis(500),
+            Duration::from_millis(5),
+            Duration::from_millis(100),
+            format!("http://{:}:{:}/", addr.ip(), addr.port()).as_str(),
+        )
+        .await;
+
+        cancel_token.cancel();
+
+        let requests = server.await.unwrap();
+
+        if super::HARDFAIL_CODES.contains(statuscode) {
+            assert_eq!(requests, 1);
+        }
+
+        if *statuscode == StatusCode::OK {
+            assert_eq!(requests, 1);
+        }
+
+        if super::RETRY_CODES.contains(statuscode) {
+            assert!(requests >= 10);
+        }
+
+        res.is_ok()
+    }
+
+    // Assert requests that don't receive data after the connection is accepted retry.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn get_slow_write() {
+        let serverlistener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = serverlistener.local_addr().unwrap();
+        let task_cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_token = task_cancel.clone();
+        let server = tokio::spawn(async move {
+            let mut requests_accepted = 0;
+            loop {
+                tokio::select! {
+                    _ = task_cancel.cancelled() => {
+                        break;
+                    }
+                    _ = async {
+                        let (mut serverstream, _) = serverlistener.accept().await.unwrap();
+                        requests_accepted += 1;
+                        // Do this asynchronously so we accept the next request in a timely manner;
+                        // there's a separate test for slow accepts.
+                        tokio::spawn(async move {
+                            tokio::time::sleep(Duration::from_millis(200)).await;
+                            let _ = serverstream.write_all(
+                                get_http_response_payload(&StatusCode::FORBIDDEN, "too slow").as_bytes()
+                            ).await;
+                        });
+                    } => {}
+                }
+            }
+            requests_accepted
+        });
+
+        let client = Client::builder().build().unwrap();
+
+        let res = super::get(
+            &client,
+            header::HeaderMap::new(),
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(500),
+            format!("http://{:}:{:}/", addr.ip(), addr.port()).as_str(),
+        )
+        .await;
+
+        cancel_token.cancel();
+
+        let requests = server.await.unwrap();
+        assert!(requests >= 2);
+        match res {
+            Err(crate::error::Error::Timeout) => {}
+            _ => panic!("Response should have timed out"),
+        };
+    }
+
+    // Assert requests that never get accepted retry
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn get_slow_accept() {
+        let serverlistener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = serverlistener.local_addr().unwrap();
+        let task_cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_token = task_cancel.clone();
+        let server = tokio::spawn(async move {
+            let mut requests_attempted = 0;
+            loop {
+                tokio::select! {
+                    _ = task_cancel.cancelled() => {
+                        break;
+                    }
+                    _ = async {
+                        requests_attempted += 1;
+                        tokio::time::sleep(Duration::from_millis(150)).await;
+                        let _ = serverlistener.accept().await;
+                    } => {}
+                }
+            }
+            requests_attempted
+        });
+
+        let client = Client::builder().build().unwrap();
+
+        let res = super::get(
+            &client,
+            header::HeaderMap::new(),
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(1000),
+            format!("http://{:}:{:}/", addr.ip(), addr.port()).as_str(),
+        )
+        .await;
+
+        cancel_token.cancel();
+
+        let requests = server.await.unwrap();
+        assert!(requests >= 2);
+        match res {
+            Err(crate::error::Error::Timeout) => {}
+            _ => panic!("Response should have timed out"),
+        };
+    }
+
+    // Assert a response with 200 OK is returned.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn get_ok() {
+        assert!(serve_valid_http_with(&StatusCode::OK, BODY_CONTENTS).await);
+        assert!(logs_contain("HTTP response succeeded with status 200 OK"));
+    }
+
+    // Assert status codes in the list are retried
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn get_retry_responses() {
+        for rc in super::RETRY_CODES {
+            assert!(!serve_valid_http_with(rc, BODY_CONTENTS).await);
+        }
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn get_fast_fail() {
+        // status codes that should result into immediate failures.
+        for rc in super::HARDFAIL_CODES {
+            assert!(!serve_valid_http_with(rc, BODY_CONTENTS).await);
+        }
+    }
+}

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -143,7 +143,7 @@ where
 }
 
 const DEFAULT_IMDS_URL: &str =
-    "http://169.254.169.254/metadata/instance?api-version=2021-02-01";
+    "http://169.254.169.254/metadata/instance?api-version=2023-11-15&extended=true";
 
 /// Send queries to IMDS to fetch Azure instance metadata.
 ///


### PR DESCRIPTION
This is best reviewed commit-by-commit. The first commit just improves error messages by including their underlying source. The next commit refactors the retry loops so there's one common implementation. I added some additional test cases for this common implementation that cover a server that fail to `accept()` a connection fast enough, or one that `accept()`s and never writes a response.

The last commit handles the case where the body can't be deserialized, in which case we retry the request. I'm not sure if we should ever expect that to happen, and I don't love the way I implemented it since it requires that we track how the overall timeout. If people don't love this and think it's not an error case worth retrying, we can drop it.


