### PR TITLE
Updating sshd config for PasswordAuthentication

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -20,6 +20,7 @@ block-utils = "0.11.1"
 tracing = "0.1.40"
 strum = { version = "0.26.3", features = ["derive"] }
 fstab = "0.4.0"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -7,6 +7,8 @@ use tracing::instrument;
 
 use crate::{error::Error, User};
 
+use super::ssh::update_sshd_config;
+
 /// Available tools to set the user's password (if a password is provided).
 #[derive(strum::EnumIter, Debug, Clone)]
 #[non_exhaustive]
@@ -29,6 +31,14 @@ impl Provisioner {
 
 #[instrument(skip_all)]
 fn passwd(user: &User) -> Result<(), Error> {
+    // Update the sshd configuration to allow password authentication.
+    let ret = update_sshd_config();
+    if ret.is_err() {
+        return Err(Error::SubprocessFailed {
+            command: "update_sshd_config".to_string(),
+            status: Default::default(),
+        });
+    }
     let path_passwd = env!("PATH_PASSWD");
 
     if user.password.is_none() {


### PR DESCRIPTION
Update /etc/ssh/sshd_config for PasswordAuthentication to yes and restart sshd. Fixes #67

<!-- [ Describe the change in 1 - 3 paragraphs ] -->

## How to use

<!-- [ Describe what reviewers need to do in order to validate this PR ] -->

## Testing done

<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
