### PR TITLE
Cargo: remove MSRV-pinned crates for Rust 1.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ clap = { version = "<=4.4", features = ["derive", "cargo", "env"] }
 
 [dev-dependencies]
 # Purely for the MSRV requirement.
-assert_cmd = "<=2.0.13"
-predicates = "<=3.1.0"
-predicates-core = "<=1.0.6"
-predicates-tree = "<=1.0.9"
+assert_cmd = "<=2.0.14"
+predicates = "3.1.2"
+predicates-core = "1.0.8"
+predicates-tree = "1.0.11"
 
 [dependencies.libazureinit]
 path = "libazureinit"


### PR DESCRIPTION
Remove pinned versions of crates `predicates*`, as they are now able to be compiled with Rust 1.73, CI-specfied version of Rust.
