### PR TITLE
Cargo: remove MSRV-pinned crates for Rust 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "azure-init"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.74"
 repository = "https://github.com/Azure/azure-init/"
 homepage = "https://github.com/Azure/azure-init/"
 license = "MIT"
@@ -14,15 +15,13 @@ anyhow = "1.0.81"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing = "0.1.40"
-# We work fine with any version of 4, but 4.5 bumped MSRV to 1.74
-clap = { version = "<=4.4", features = ["derive", "cargo", "env"] }
+clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 
 [dev-dependencies]
-# Purely for the MSRV requirement.
-assert_cmd = "<=2.0.13"
-predicates = "<=3.1.0"
-predicates-core = "<=1.0.6"
-predicates-tree = "<=1.0.9"
+assert_cmd = "2.0.16"
+predicates = "3.1.2"
+predicates-core = "1.0.8"
+predicates-tree = "1.0.11"
 
 [dependencies.libazureinit]
 path = "libazureinit"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libazureinit"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.74"
 build = "build.rs"
 repository = "https://github.com/Azure/azure-init/"
 homepage = "https://github.com/Azure/azure-init/"


### PR DESCRIPTION
Remove pinned versions of crates `clap`, `predicates*`, as they are now able to be compiled with Rust 1.74, CI-specfied version of Rust.

Set `package.rust-version` to 1.74 to be used by other crates that would make use of [MSRV-aware resolver](https://blog.rust-lang.org/inside-rust/2024/10/31/this-development-cycle-in-cargo-1.83.html#msrv-aware-cargo) which is available in Rust 1.83 or newer.

