### PR TITLE
Improve testing section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,41 @@ To run the program, you must enter the command `cargo run --bin <binary_name>` a
 
 ## Testing
 
-There are two different sets of tests: unit tests and end-to-end (e2e tests). To run unit tests, use `cargo test`. 
-To run end-to-end testing, use `make e2e-test`, which will create a test user, ssh directory, place mock ssh keys, and 
-then clean up the test artifacts afterwards.
+Azure-init includes two types of tests: unit tests and end-to-end (e2e) tests.
+
+### Running Unit Tests
+
+To run unit tests, use the following commands based on the scope of testing:
+
+1. **Repository-Wide Unit Tests:**
+From the root directory of the repository, run:
+
+```
+cargo test
+```
+
+This will execute the unit tests defined in the top-level binaries and modules but will **not** include tests from submodules like libazureinit.
+
+2. **Unit Tests in** `libazureinit`:
+
+To run the full set of unit tests, including those within the `libazureinit` library, navigate to the `libazureinit` directory and run:
+```
+cd libazureinit
+cargo test
+```
+
+### Running End-to-End (e2e) Tests
+End-to-end tests validate the integration of the entire system. These tests require additional setup, such as setting a subscription ID. To run e2e tests, use the following command from the repository root:
+
+```
+make e2e-test
+```
+
+This command will:
+
+1. Create a test user and associated SSH directory.
+2. Place mock SSH keys for testing.
+3. Run the tests and then clean up any test artifacts generated during the process.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,24 +29,14 @@ Azure-init includes two types of tests: unit tests and end-to-end (e2e) tests.
 
 ### Running Unit Tests
 
-To run unit tests, use the following commands based on the scope of testing:
-
-1. **Repository-Wide Unit Tests:**
 From the root directory of the repository, run:
 
 ```
-cargo test
+cargo test --verbose --all-features --workspace
 ```
 
-This will execute the unit tests defined in the top-level binaries and modules but will **not** include tests from submodules like libazureinit.
-
-2. **Unit Tests in** `libazureinit`:
-
-To run the full set of unit tests, including those within the `libazureinit` library, navigate to the `libazureinit` directory and run:
-```
-cd libazureinit
-cargo test
-```
+This will run the unit tests for every library in the repository, not just for azure-init. 
+Doing so ensures your testing will match what is run in the CI pipeline. 
 
 ### Running End-to-End (e2e) Tests
 End-to-end tests validate the integration of the entire system. These tests require additional setup, such as setting a subscription ID. To run e2e tests, use the following command from the repository root:


### PR DESCRIPTION
When ensuring the changes I made worked, I followed the instructions in the README and saw that I passed all unit tests (only 1). However, I remembered there being more tests than this, so I dug into why this occurred. The README only specifies to run `cargo test`, but does not specify that this will not run every test if you are in the root directory, which may be difficult to understand for new Rust users and/or lead to improper changes being made to the repo. This PR simply adds improved guidance on how to run unit tests.

## How to use

There is no additional usage for this PR.

## Testing done

There is no additional testing done for this PR.
