### PR TITLE
libazureinit: fix clippy warning of map_or for Rust 1.84

### DIFF
--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -342,7 +342,7 @@ impl Config {
                 .filter_map(Result::ok)
                 .map(|entry| entry.path())
                 .filter(|path| {
-                    path.extension().map_or(false, |ext| ext == "toml")
+                    path.extension().is_some_and(|ext| ext == "toml")
                 })
                 .collect();
 


### PR DESCRIPTION
Starting from Rust 1.84, clippy gives warning like below:

```
warning: this `map_or` is redundant
   --> libazureinit/src/config.rs:345:21
    |
345 |                     path.extension().map_or(false, |ext| ext == "toml")
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_some_and instead: `path.extension().is_some_and(|ext| ext == "toml")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
```

Fix that by using `is_some_and`.

See also
https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-184, https://github.com/rust-lang/rust-clippy/pull/11796.
