### PR TITLE
Add Version and Commit Hash to User-Agent String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Azure/azure-init/"
 license = "MIT"
 readme = "README.md"
 description = "A reference implementation for provisioning Linux VMs on Azure."
+build = "build.rs"
 
 [dependencies]
 exitcode = "1.1.2"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+fn main() {
+    // Get the short commit hash
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("Failed to execute git command");
+
+    let git_hash =
+        String::from_utf8(output.stdout).expect("Invalid UTF-8 sequence");
+
+    // Set the environment variable
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash.trim());
+}

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 fn main() {
     // Get the short commit hash
     let output = Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
         .expect("Failed to execute git command");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ async fn main() -> ExitCode {
 async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
     let mut default_headers = header::HeaderMap::new();
     let user_agent = if cfg!(debug_assertions) {
-        format!("azure-init {}-{}", VERSION, COMMIT_HASH)
+        format!("azure-init v{}-{}", VERSION, COMMIT_HASH)
     } else {
         format!("azure-init {}", VERSION)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 
+// These should be set during the build process
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 
 /// Minimal provisioning agent for Azure
 ///
@@ -133,9 +135,12 @@ async fn main() -> ExitCode {
 #[instrument]
 async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
     let mut default_headers = header::HeaderMap::new();
-    let user_agent = header::HeaderValue::from_str(
-        format!("azure-init v{VERSION}").as_str(),
-    )?;
+    let user_agent = if cfg!(debug_assertions) {
+        format!("azure-init {}-{}", VERSION, COMMIT_HASH)
+    } else {
+        format!("azure-init {}", VERSION)
+    };
+    let user_agent = header::HeaderValue::from_str(user_agent.as_str())?;
     default_headers.insert(header::USER_AGENT, user_agent);
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(30))

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
     let user_agent = if cfg!(debug_assertions) {
         format!("azure-init v{}-{}", VERSION, COMMIT_HASH)
     } else {
-        format!("azure-init {}", VERSION)
+        format!("azure-init v{}", VERSION)
     };
     let user_agent = header::HeaderValue::from_str(user_agent.as_str())?;
     default_headers.insert(header::USER_AGENT, user_agent);


### PR DESCRIPTION
This PR updates azure-init to send its version (e.g., `azure-init v0.1.1`) as part of the User-Agent string for released binaries. For nightly tests, it appends the commit hash to the existing version (e.g., `azure-init v0.1.1-abc1234`).

## Testing done

I have tested this change using a newly created local binary crate to ensure that the environment variable works as expected. However, I do not have the setup to test azure-init directly. Any guidance on testing `azure-init` would be appreciated.
