### PR TITLE
Standardize logging when running subprocesses

### DIFF
--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -16,3 +16,46 @@ mod unittest;
 
 // Re-export as the Client is used in our API.
 pub use reqwest;
+
+/// Run a command, capturing its output and logging it if it fails.
+///
+/// In the event of a failure, the provided `error_message` is logged at
+/// error level.
+///
+/// <div class="warning">
+///
+/// This logs the command and its arguments, and as such is not appropriate
+/// if the command contains sensitive information.
+///
+/// </div>
+pub(crate) fn run(
+    mut command: std::process::Command,
+) -> Result<(), error::Error> {
+    let program = command.get_program().to_string_lossy().to_string();
+    let span = tracing::info_span!("subprocess", program);
+    let _entered = span.enter();
+
+    tracing::debug!(?command, "About to execute system program");
+    let output = command.output()?;
+    let status = output.status;
+    tracing::debug!(?status, "System program completed");
+
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        tracing::error!(
+            ?status,
+            ?command,
+            ?stdout,
+            ?stderr,
+            "Command '{}' failed",
+            program
+        );
+        return Err(error::Error::SubprocessFailed {
+            command: format!("{:?}", command),
+            status,
+        });
+    }
+
+    Ok(())
+}

--- a/libazureinit/src/provision/hostname.rs
+++ b/libazureinit/src/provision/hostname.rs
@@ -23,16 +23,7 @@ impl HostnameProvisioner {
 fn hostnamectl(hostname: &str) -> Result<(), Error> {
     let path_hostnamectl = env!("PATH_HOSTNAMECTL");
 
-    let status = Command::new(path_hostnamectl)
-        .arg("set-hostname")
-        .arg(hostname)
-        .status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(Error::SubprocessFailed {
-            command: path_hostnamectl.to_string(),
-            status,
-        })
-    }
+    let mut command = Command::new(path_hostnamectl);
+    command.arg("set-hostname").arg(hostname);
+    crate::run(command)
 }

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -38,26 +38,7 @@ fn passwd(user: &User) -> Result<(), Error> {
     if user.password.is_none() {
         let mut command = Command::new(path_passwd);
         command.arg("-d").arg(&user.name);
-        tracing::trace!(?command, "About to remove user's password");
-        let output = command.output()?;
-        let status = output.status;
-        tracing::info!("Removed user password");
-
-        if !status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            tracing::error!(
-                ?status,
-                command = path_passwd,
-                ?stdout,
-                ?stderr,
-                "Failed to remove the user password"
-            );
-            return Err(Error::SubprocessFailed {
-                command: path_passwd.to_string(),
-                status,
-            });
-        }
+        crate::run(command)?;
     } else {
         // creating user with a non-empty password is not allowed.
         return Err(Error::NonEmptyPassword);

--- a/libazureinit/src/provision/user.rs
+++ b/libazureinit/src/provision/user.rs
@@ -123,12 +123,12 @@ impl UserProvisioner {
 
 #[instrument(skip_all)]
 fn user_exists(username: &str) -> Result<bool, Error> {
-    let status = Command::new("getent")
+    let output = Command::new("getent")
         .arg("passwd")
         .arg(username)
-        .status()?;
+        .output()?;
 
-    Ok(status.success())
+    Ok(output.status.success())
 }
 
 #[instrument(skip_all)]
@@ -147,63 +147,24 @@ fn useradd(user: &User) -> Result<(), Error> {
             group_list
         );
 
-        let usermod_command =
-            format!("usermod -aG {} {}", group_list, user.name);
-
-        tracing::debug!("Running command: {}", usermod_command);
-
-        let status = Command::new("usermod")
-            .arg("-aG")
-            .arg(&group_list)
-            .arg(&user.name)
-            .status()?;
-
-        tracing::debug!("usermod command exit status: {}", status);
-
-        if !status.success() {
-            return Err(Error::SubprocessFailed {
-                command: usermod_command,
-                status,
-            });
-        }
-
-        return Ok(());
+        let mut command = Command::new("usermod");
+        command.arg("-aG").arg(&group_list).arg(&user.name);
+        return crate::run(command);
     }
 
     let path_useradd = env!("PATH_USERADD");
-    let home_path = format!("/home/{}", user.name);
 
-    let useradd_command = format!(
-        "{} {} --comment 'azure-init created this user based on username provided in IMDS' --groups {} -d {} -m",
-        path_useradd,
-        user.name,
-        user.groups.join(","),
-        home_path
-    );
-
-    tracing::debug!("Running command: {}", useradd_command);
-
-    let status = Command::new(path_useradd)
+    let mut command = Command::new(path_useradd);
+    command
         .arg(&user.name)
         .arg("--comment")
         .arg("azure-init created this user based on username provided in IMDS")
         .arg("--groups")
         .arg(user.groups.join(","))
         .arg("-d")
-        .arg(home_path)
-        .arg("-m")
-        .status()?;
-
-    tracing::debug!("useradd command exit status: {}", status);
-
-    if !status.success() {
-        return Err(Error::SubprocessFailed {
-            command: useradd_command,
-            status,
-        });
-    }
-
-    Ok(())
+        .arg(format!("/home/{}", user.name))
+        .arg("-m");
+    crate::run(command)
 }
 
 fn add_user_for_passwordless_sudo(


### PR DESCRIPTION
This adds a helper function which accepts a Command to run and has uniform logging when running a command.

The command is logged at the debug level prior to execution, and afterwards the status is also logged at debug level. If the command failed, it's logged at error level and includes the command's stdout and stderr.

This also ensures all commands run used piped stdio rather than inheriting the parent. Allowing the child to write to the parent stdout/stderr leads to unstructured command output mixed into the stderr log output. The easiest way to do this is to use `output()` rather than `status()` when running the command.

Example error output:
```
2025-01-23T17:19:11.264123Z ERROR libazureinit: Command 'hostnamectl' failed status=ExitStatus(unix_wait_status(256)) command="hostnamectl" "set-hostname" "my-fancy-hostname" stdout="" stderr="Could not set transient hostname: Interactive authentication required.\n"
```