### PR TITLE
Amend password and sshd logic to support Mariner OS

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -23,7 +23,6 @@ fstab = "0.4.0"
 toml = "0.8"
 regex = "1"
 lazy_static = "1.4"
-tempfile = "3.3.0"
 figment = { version = "0.10", features = ["toml"] }
 
 [dev-dependencies]

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -3,7 +3,7 @@
 
 use std::process::Command;
 
-use std::fs::read_to_string;
+use std::path::PathBuf;
 
 use tracing::instrument;
 
@@ -23,15 +23,15 @@ impl PasswordProvisioner {
     }
 }
 
-// Function to determine the SSH config path based on the OS
-// Default for Ubuntu is:  "/etc/ssh/sshd_config.d/50-azure-init.conf"
+// Determines the appropriate SSH configuration file path based on the filesystem.
+// If the "/etc/ssh/sshd_config.d" directory exists, it returns the path for a drop-in configuration file.
+// Otherwise, it defaults to the main SSH configuration file at "/etc/ssh/sshd_config".
 fn get_sshd_config_path() -> &'static str {
-    if let Ok(content) = read_to_string("/etc/os-release") {
-        if content.contains("ID=azurelinux") {
-            return "/etc/ssh/sshd_config";
-        }
+    if PathBuf::from("/etc/ssh/sshd_config.d").is_dir() {
+        "/etc/ssh/sshd_config.d/50-azure-init.conf"
+    } else {
+        "/etc/ssh/sshd_config"
     }
-    "/etc/ssh/sshd_config.d/50-azure-init.conf"
 }
 
 #[instrument(skip_all)]

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -250,23 +250,12 @@ pub(crate) fn update_sshd_config(
         temp_file.write_all(modified_content.as_bytes())?;
         temp_file.set_permissions(fs::Permissions::from_mode(0o644))?;
 
-        // Conditional logic for Mariner
-        if sshd_config_path == PathBuf::from("/etc/ssh/sshd_config") {
-            // Use fs::copy and fs::remove_file for Mariner
-            fs::copy(temp_sshd_config_path, &sshd_config_path)?;
-            fs::remove_file(temp_sshd_config_path)?;
-            tracing::info!(
-                ?sshd_config_path,
-                "Updated existing sshd setting to allow password authentication (Mariner)"
-            );
-        } else {
-            // Use fs::rename for other systems
-            fs::rename(temp_sshd_config_path, &sshd_config_path)?;
-            tracing::info!(
-                ?sshd_config_path,
-                "Updated existing sshd setting to allow password authentication (default)"
-            );
-        }
+        fs::copy(temp_sshd_config_path, &sshd_config_path)?;
+        fs::remove_file(temp_sshd_config_path)?;
+        tracing::info!(
+            ?sshd_config_path,
+            "Updated existing sshd setting to allow password authentication (Mariner)"
+        )
     } else {
         let mut file =
             OpenOptions::new().append(true).open(&sshd_config_path)?;

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -236,15 +236,16 @@ pub(crate) fn update_sshd_config(
 
     let re = &PASSWORD_REGEX;
     if re.is_match(&file_content) {
-        let modified_content =
-            re.replace_all(&file_content, "PasswordAuthentication yes\n");
+        let modified_content = re.replace_all(
+            &file_content,
+            "PasswordAuthentication yes # modified by azure-init\n",
+        );
 
         let mut sshd_config = OpenOptions::new()
             .write(true)
             .truncate(true)
             .open(&sshd_config_path)?;
         sshd_config.write_all(modified_content.as_bytes())?;
-        sshd_config.set_permissions(Permissions::from_mode(0o600))?;
 
         tracing::info!(
             ?sshd_config_path,

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -253,8 +253,7 @@ pub(crate) fn update_sshd_config(
     } else {
         let mut file =
             OpenOptions::new().append(true).open(&sshd_config_path)?;
-        file.write_all(b"PasswordAuthentication yes\n")?;
-        file.set_permissions(Permissions::from_mode(0o600))?;
+        file.write_all(b"PasswordAuthentication yes # added by azure-init\n")?;
 
         tracing::info!(
             ?sshd_config_path,

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -13,14 +13,13 @@ use nix::unistd::{chown, User};
 use regex::Regex;
 use std::{
     fs::{
-        self, OpenOptions, {File, Permissions},
+        OpenOptions, {File, Permissions},
     },
     io::{self, Read, Write},
     os::unix::fs::{DirBuilderExt, PermissionsExt},
     path::PathBuf,
     process::{Command, Output},
 };
-use tempfile::NamedTempFile;
 use tracing::{error, info, instrument};
 
 lazy_static! {
@@ -220,7 +219,7 @@ pub(crate) fn update_sshd_config(
     let sshd_config_path = PathBuf::from(sshd_config_path);
     if !sshd_config_path.exists() {
         let mut file = std::fs::File::create(&sshd_config_path)?;
-        file.set_permissions(Permissions::from_mode(0o644))?;
+        file.set_permissions(Permissions::from_mode(0o600))?;
         file.write_all(b"PasswordAuthentication yes\n")?;
         tracing::info!(
             ?sshd_config_path,
@@ -240,30 +239,27 @@ pub(crate) fn update_sshd_config(
         let modified_content =
             re.replace_all(&file_content, "PasswordAuthentication yes\n");
 
-        let temp_sshd_config = NamedTempFile::new()?;
-        let temp_sshd_config_path = temp_sshd_config.path();
-        let mut temp_file = OpenOptions::new()
+        let mut sshd_config = OpenOptions::new()
             .write(true)
-            .create(true)
             .truncate(true)
-            .open(temp_sshd_config_path)?;
-        temp_file.write_all(modified_content.as_bytes())?;
-        temp_file.set_permissions(fs::Permissions::from_mode(0o644))?;
+            .open(&sshd_config_path)?;
+        sshd_config.write_all(modified_content.as_bytes())?;
+        sshd_config.set_permissions(Permissions::from_mode(0o600))?;
 
-        fs::copy(temp_sshd_config_path, &sshd_config_path)?;
-        fs::remove_file(temp_sshd_config_path)?;
         tracing::info!(
             ?sshd_config_path,
-            "Updated existing sshd setting to allow password authentication (Mariner)"
-        )
+            "Updated existing sshd setting to allow password authentication"
+        );
     } else {
         let mut file =
             OpenOptions::new().append(true).open(&sshd_config_path)?;
         file.write_all(b"PasswordAuthentication yes\n")?;
+        file.set_permissions(Permissions::from_mode(0o600))?;
+
         tracing::info!(
             ?sshd_config_path,
             "Added new sshd setting to allow password authentication"
-        )
+        );
     }
 
     Ok(())

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -250,11 +250,23 @@ pub(crate) fn update_sshd_config(
         temp_file.write_all(modified_content.as_bytes())?;
         temp_file.set_permissions(fs::Permissions::from_mode(0o644))?;
 
-        fs::rename(temp_sshd_config_path, &sshd_config_path)?;
-        tracing::info!(
-            ?sshd_config_path,
-            "Updated existing sshd setting to allow password authentication"
-        )
+        // Conditional logic for Mariner
+        if sshd_config_path == PathBuf::from("/etc/ssh/sshd_config") {
+            // Use fs::copy and fs::remove_file for Mariner
+            fs::copy(temp_sshd_config_path, &sshd_config_path)?;
+            fs::remove_file(temp_sshd_config_path)?;
+            tracing::info!(
+                ?sshd_config_path,
+                "Updated existing sshd setting to allow password authentication (Mariner)"
+            );
+        } else {
+            // Use fs::rename for other systems
+            fs::rename(temp_sshd_config_path, &sshd_config_path)?;
+            tracing::info!(
+                ?sshd_config_path,
+                "Updated existing sshd setting to allow password authentication (default)"
+            );
+        }
     } else {
         let mut file =
             OpenOptions::new().append(true).open(&sshd_config_path)?;


### PR DESCRIPTION
This PR amends the password and SSHD configuration logic to support Mariner OS while retaining compatibility with Ubuntu.

Key changes:

1. Added an OS check to determine the appropriate SSHD configuration path. If the OS is Mariner, the script uses `/etc/ssh/sshd_config`; otherwise, it defaults to Ubuntu's `/etc/ssh/sshd_config.d/50-azure-init.conf`.

2. Modified `update_sshd_config` to address a cross-device link error on Mariner when using `fs::rename`. For Mariner, the logic now uses `fs::copy` to copy the temporary file to the target location and `fs::remove_file` to clean up the temporary file. For non-Mariner systems, the existing `fs::rename` logic remains unchanged.
