### PR TITLE
Update opentelemetry(_sdk) to 0.27, tracing-opentelemetry 0.28, fix build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ sysinfo = "0.27"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.27"
 opentelemetry_sdk = "0.27"
-tracing-opentelemetry = "0.27"
+tracing-opentelemetry = "0.28"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.27"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.26"
-opentelemetry_sdk = "0.26"
+opentelemetry_sdk = "0.27"
 tracing-opentelemetry = "0.27"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.27"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.26"
+opentelemetry = "0.27"
 opentelemetry_sdk = "0.27"
 tracing-opentelemetry = "0.27"
 uuid = { version = "1.2", features = ["v4"] }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,7 +3,7 @@
 
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_sdk::trace::{
-    self as sdktrace, Config, Sampler, TracerProvider as SdkTracerProvider,
+    self as sdktrace, Sampler, TracerProvider as SdkTracerProvider,
 };
 use tracing::{event, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -15,9 +15,9 @@ use tracing_subscriber::{
 use crate::kvp::EmitKVPLayer;
 
 pub fn initialize_tracing() -> sdktrace::Tracer {
-    let config = Config::default().with_sampler(Sampler::AlwaysOn);
-
-    let provider = SdkTracerProvider::builder().with_config(config).build();
+    let provider = SdkTracerProvider::builder()
+        .with_sampler(Sampler::AlwaysOn)
+        .build();
 
     global::set_tracer_provider(provider.clone());
     provider.tracer("azure-kvp")


### PR DESCRIPTION
Update `opentelemetry` & `opentelemetry_sdk` to 0.27.1, `tracing-opentelemetry` to 0.28.
(Replaces https://github.com/Azure/azure-init/pull/158, https://github.com/Azure/azure-init/pull/159, https://github.com/Azure/azure-init/pull/160)

Fix build issues with opentelemetry(_sdk) 0.27 or newer as well as tracing-opentelemetry 0.28 or newer. As opentelemetry 0.27 or newer does not have a method `with_config` for TraceBuilder, it is necessary to call `with_sampler` directly from TraceBuilder without `with_config`.

See also https://github.com/open-telemetry/opentelemetry-rust/pull/2303.
