### PR TITLE
Adding Cached VM ID File for Provisioning Lifecycle Management 

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -25,7 +25,6 @@ regex = "1"
 lazy_static = "1.4"
 figment = { version = "0.10", features = ["toml"] }
 uuid = "1.3"
-byteorder = "1.4"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -24,6 +24,8 @@ toml = "0.8"
 regex = "1"
 lazy_static = "1.4"
 figment = { version = "0.10", features = ["toml"] }
+uuid = "1.3"
+byteorder = "1.4"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -224,29 +224,29 @@ impl Default for Telemetry {
     }
 }
 
-/// The default directory for storing provisioning status files.
+/// The default directory for storing azure-init data files, such as the provisioning status file.
 ///
-/// This constant is declared outside its related struct so that both the `ProvisioningDir` struct
+/// This constant is declared outside its related struct so that both the `AzureInitDataDir` struct
 /// and other modules (like `status.rs`) can reference the same path without risking any mismatch.
-pub const DEFAULT_PROVISIONING_DIR: &str = "/var/lib/azure-init/";
+pub const DEFAULT_AZURE_INIT_DATA_DIR: &str = "/var/lib/azure-init/";
 
-/// Provisioning directory configuration struct.
+/// Azure-init data directory directory configuration struct.
 ///
-/// Configures settings for where azure-init should store provisioning-related files.
-/// If no custom path is provided, `ProvisioningDir::default()` uses
-/// [`DEFAULT_PROVISIONING_DIR`], ensuring a single source of truth.
+/// Configures settings for where azure-init should store data (especially provisioning-related) files.
+/// If no custom path is provided, `AzureInitDataDir::default()` uses
+/// [`DEFAULT_AZURE_INIT_DATA_DIR`], ensuring a single source of truth.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct ProvisioningDir {
-    /// Specifies the path used for storing provisioning status files.
+pub struct AzureInitDataDir {
+    /// Specifies the path used for storing azure-init data files.
     /// Defaults to `/var/lib/azure-init/`.
     pub path: PathBuf,
 }
 
-impl Default for ProvisioningDir {
+impl Default for AzureInitDataDir {
     fn default() -> Self {
         Self {
-            path: PathBuf::from(DEFAULT_PROVISIONING_DIR),
+            path: PathBuf::from(DEFAULT_AZURE_INIT_DATA_DIR),
         }
     }
 }
@@ -267,7 +267,7 @@ pub struct Config {
     pub azure_proxy_agent: AzureProxyAgent,
     pub wireserver: Wireserver,
     pub telemetry: Telemetry,
-    pub provisioning_dir: ProvisioningDir,
+    pub azure_init_data_dir: AzureInitDataDir,
 }
 
 /// Implements `Display` for `Config`, formatting it as a readable TOML string.
@@ -626,7 +626,7 @@ mod tests {
         assert!(config.telemetry.kvp_diagnostics);
 
         assert_eq!(
-            config.provisioning_dir.path.to_str().unwrap(),
+            config.azure_init_data_dir.path.to_str().unwrap(),
             "/var/lib/azure-init/",
         );
 
@@ -663,8 +663,8 @@ mod tests {
         enable = false
         [telemetry]
         kvp_diagnostics = false
-        [provisioning_dir]
-        path = "/custom/provisioning/dir"
+        [azure_init_data_dir]
+        path = "/custom/azure-init-data-dir"
         "#
         )?;
 
@@ -722,11 +722,11 @@ mod tests {
         assert!(!config.telemetry.kvp_diagnostics);
 
         tracing::debug!(
-            "Verifying merged provisioning directory configuration..."
+            "Verifying merged azure-init data directory configuration..."
         );
         assert_eq!(
-            config.provisioning_dir.path.to_str().unwrap(),
-            "/custom/provisioning/dir"
+            config.azure_init_data_dir.path.to_str().unwrap(),
+            "/custom/azure-init-data-dir"
         );
 
         tracing::debug!(
@@ -794,10 +794,10 @@ mod tests {
         assert!(config.telemetry.kvp_diagnostics);
 
         tracing::debug!(
-            "Verifying default provisioning directory configuration..."
+            "Verifying default azure-init data directory configuration..."
         );
         assert_eq!(
-            config.provisioning_dir.path.to_str().unwrap(),
+            config.azure_init_data_dir.path.to_str().unwrap(),
             "/var/lib/azure-init/"
         );
 
@@ -831,8 +831,8 @@ mod tests {
         enable = false
         [telemetry]
         kvp_diagnostics = false
-        [provisioning_dir]
-        path = "/cli-override-provisioning-dir"
+        [azure_init_data_dir]
+        path = "/cli-override-azure-init-data-dir"
         "#,
         )?;
 
@@ -876,8 +876,8 @@ mod tests {
         assert!(!config.azure_proxy_agent.enable);
         assert!(!config.telemetry.kvp_diagnostics);
         assert_eq!(
-            config.provisioning_dir.path.to_str().unwrap(),
-            "/cli-override-provisioning-dir"
+            config.azure_init_data_dir.path.to_str().unwrap(),
+            "/cli-override-azure-init-data-dir"
         );
 
         Ok(())

--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -224,9 +224,17 @@ impl Default for Telemetry {
     }
 }
 
+/// The default directory for storing provisioning status files.
+///
+/// This constant is declared outside its related struct so that both the `ProvisioningDir` struct
+/// and other modules (like `status.rs`) can reference the same path without risking any mismatch.
+pub const DEFAULT_PROVISIONING_DIR: &str = "/var/lib/azure-init/";
+
 /// Provisioning directory configuration struct.
 ///
 /// Configures settings for where azure-init should store provisioning-related files.
+/// If no custom path is provided, `ProvisioningDir::default()` uses
+/// [`DEFAULT_PROVISIONING_DIR`], ensuring a single source of truth.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct ProvisioningDir {
@@ -238,7 +246,7 @@ pub struct ProvisioningDir {
 impl Default for ProvisioningDir {
     fn default() -> Self {
         Self {
-            path: PathBuf::from("/var/lib/azure-init/"),
+            path: PathBuf::from(DEFAULT_PROVISIONING_DIR),
         }
     }
 }

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -10,6 +10,8 @@ pub mod media;
 
 mod provision;
 pub use provision::{user::User, Provision};
+mod status;
+pub use status::{is_provisioning_complete, mark_provisioning_complete};
 
 #[cfg(test)]
 mod unittest;

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -11,7 +11,9 @@ pub mod media;
 mod provision;
 pub use provision::{user::User, Provision};
 mod status;
-pub use status::{is_provisioning_complete, mark_provisioning_complete};
+pub use status::{
+    get_vm_id, is_provisioning_complete, mark_provisioning_complete,
+};
 
 #[cfg(test)]
 mod unittest;

--- a/libazureinit/src/status.rs
+++ b/libazureinit/src/status.rs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Provisioning status management for azure-init.
+//!
+//! This module ensures that provisioning is performed only when necessary
+//! by tracking the VM ID. It stores a provisioning status file named after
+//! the VM ID in a persistent location (`/var/lib/azure-init/`).
+//!
+//! # Logic Overview
+//! - Retrieves the VM ID using `dmidecode`.
+//! - Determines if provisioning is required by checking if a status file exists.
+//! - Creates the provisioning status file upon successful provisioning.
+//! - Prevents unnecessary re-provisioning on reboot, unless the VM ID changes.
+//!
+//! # Behavior
+//! - On **first boot**, provisioning runs and a file is created: `/var/lib/azure-init/{vm_id}`
+//! - On **reboot**, if the same VM ID exists, provisioning is skipped.
+//! - If the **VM ID changes** (e.g., due to VM cloning), provisioning runs again.
+
+use std::env;
+use std::fs::{self, File};
+use std::path::Path;
+use std::process::Command;
+
+use crate::error::Error;
+
+/// Directory where the provisioning status files are stored.
+const DEFAULT_PROVISION_DIR: &str = "/var/lib/azure-init/";
+
+fn get_provisioning_dir() -> String {
+    env::var("TEST_PROVISION_DIR")
+        .unwrap_or_else(|_| DEFAULT_PROVISION_DIR.to_string())
+}
+
+/// This function checks if the provisioning directory is present, and if not,
+/// it creates it.
+fn check_provision_dir() -> Result<(), Error> {
+    let dir = get_provisioning_dir();
+    if !Path::new(&dir).exists() {
+        fs::create_dir_all(&dir)?;
+        tracing::info!("Created provisioning directory: {}", &dir);
+    }
+    Ok(())
+}
+
+/// Retrieves the VM ID using `dmidecode`.
+///
+/// The VM ID is a unique system identifier that persists across reboots but changes
+/// when a VM is cloned or redeployed.
+///
+/// # Returns
+/// - `Some(String)` containing the VM ID if retrieval is successful.
+/// - `None` if `dmidecode` fails or the output is empty.
+fn get_vm_id() -> Option<String> {
+    // Test override check
+    if let Ok(mock_id) = std::env::var("MOCK_VM_ID") {
+        return Some(mock_id);
+    }
+
+    Command::new("dmidecode")
+        .args(["-s", "system-uuid"])
+        .output()
+        .ok()
+        .map(|output| {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        })
+        .filter(|vm_id| !vm_id.is_empty())
+}
+
+/// This function checks whether a provisioning status file exists for the current VM ID.
+/// If the file exists, provisioning has already been completed and should be skipped.
+/// If the file does not exist or the VM ID has changed, provisioning should proceed.
+///
+/// - Returns `true` if provisioning is complete (i.e., provisioning file exists).
+/// - Returns `false` if provisioning has not been completed (i.e., no provisioning file exists).
+pub fn is_provisioning_complete() -> bool {
+    if let Some(vm_id) = get_vm_id() {
+        let file_path =
+            format!("{}/{}.provisioned", get_provisioning_dir(), vm_id);
+        if std::path::Path::new(&file_path).exists() {
+            tracing::info!("Provisioning already complete. Skipping...");
+            return true;
+        }
+    }
+    tracing::info!("Provisioning required.");
+    false
+}
+
+/// This function creates an empty file named after the current VM ID in the
+/// provisioning directory. The presence of this file signals that provisioning
+/// has been successfully completed.
+pub fn mark_provisioning_complete() -> Result<(), Error> {
+    check_provision_dir()?;
+
+    if let Some(vm_id) = get_vm_id() {
+        let file_path =
+            format!("{}/{}.provisioned", get_provisioning_dir(), vm_id);
+
+        if let Err(error) = File::create(&file_path) {
+            tracing::error!(
+                ?error,
+                file_path,
+                "Failed to create provisioning status file"
+            );
+            return Err(error.into());
+        }
+
+        tracing::info!(
+            target: "libazureinit::status::success",
+            "Provisioning complete. File created: {}",
+            file_path
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_mark_provisioning_complete() {
+        let test_dir = TempDir::new().unwrap();
+        std::env::set_var(
+            "TEST_PROVISION_DIR",
+            test_dir.path().to_str().unwrap(),
+        );
+
+        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-123");
+
+        let file_path = test_dir.path().join("FAKE-VM-ID-123.provisioned");
+        assert!(
+            !file_path.exists(),
+            "File should not exist before provisioning"
+        );
+        mark_provisioning_complete().unwrap();
+        assert!(file_path.exists(), "Provisioning file should be created");
+    }
+
+    #[test]
+    fn test_is_provisioning_complete() {
+        let test_dir = TempDir::new().unwrap();
+        std::env::set_var(
+            "TEST_PROVISION_DIR",
+            test_dir.path().to_str().unwrap(),
+        );
+        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-456");
+
+        assert!(
+            !is_provisioning_complete(),
+            "Provisioning should be needed if file doesn't exist"
+        );
+
+        let file_path = test_dir.path().join("FAKE-VM-ID-456.provisioned");
+        fs::File::create(&file_path).unwrap();
+        assert!(
+            is_provisioning_complete(),
+            "Provisioning should be complete if file exists"
+        );
+    }
+
+    #[test]
+    fn test_provisioning_skipped_on_simulated_reboot() {
+        let test_dir = TempDir::new().unwrap();
+        std::env::set_var(
+            "TEST_PROVISION_DIR",
+            test_dir.path().to_str().unwrap(),
+        );
+        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-999");
+        assert!(
+            !is_provisioning_complete(),
+            "Should need provisioning initially"
+        );
+
+        mark_provisioning_complete().unwrap();
+
+        // Simulate a "reboot" by calling again
+        assert!(
+            is_provisioning_complete(),
+            "Provisioning should be skipped on second run (file exists)"
+        );
+    }
+}

--- a/libazureinit/src/status.rs
+++ b/libazureinit/src/status.rs
@@ -8,8 +8,10 @@
 //! the VM ID in a persistent location (`/var/lib/azure-init/`).
 //!
 //! # Logic Overview
-//! - Retrieves the VM ID using reading `/sys/class/dmi/id/product_uuid` and byte-swapping if gen1 VM.
+//! - Retrieves the VM ID using reading `/sys/class/dmi/id/product_uuid` and byte-swapping if Gen1 VM.
 //! - Determines if provisioning is required by checking if a status file exists.
+//! - The provisioning directory is configurable via the Config struct (defaulting to `/var/lib/azure-init/`),
+//!   but can be overridden via environment variables for testing.
 //! - Creates the provisioning status file upon successful provisioning.
 //! - Prevents unnecessary re-provisioning on reboot, unless the VM ID changes.
 //!
@@ -18,47 +20,68 @@
 //! - On **reboot**, if the same VM ID exists, provisioning is skipped.
 //! - If the **VM ID changes** (e.g., due to VM cloning), provisioning runs again.
 
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use byteorder::{BigEndian, ByteOrder};
 use std::env;
 use std::fs::{self, File};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
+use crate::config::Config;
 use crate::error::Error;
 
-/// Directory where the provisioning status files are stored.
-const DEFAULT_PROVISION_DIR: &str = "/var/lib/azure-init/";
+/// This function first checks if the environment variable `AZURE_INIT_TEST_PROVISIONING_DIR`
+/// is set (used primarily in tests). If set, it returns that directory. Otherwise, if a Config
+/// is provided, it returns the directory specified by `config.provisioning_dir.path`. If no Config
+/// is provided, it falls back to the default path `/var/lib/azure-init/`.
+fn get_provisioning_dir(config: Option<&Config>) -> PathBuf {
+    if let Ok(env_dir) = env::var("AZURE_INIT_TEST_PROVISIONING_DIR") {
+        return PathBuf::from(env_dir);
+    }
 
-fn get_provisioning_dir() -> String {
-    env::var("TEST_PROVISION_DIR")
-        .unwrap_or_else(|_| DEFAULT_PROVISION_DIR.to_string())
+    // If config is provided, use config.provisioning_dir.path
+    // Otherwise, fallback to /var/lib/azure-init/.
+    config
+        .map(|cfg| cfg.provisioning_dir.path.clone())
+        .unwrap_or_else(|| PathBuf::from("/var/lib/azure-init/"))
 }
 
 /// This function checks if the provisioning directory is present, and if not,
 /// it creates it.
-fn check_provision_dir() -> Result<(), Error> {
-    let dir = get_provisioning_dir();
-    if !Path::new(&dir).exists() {
+fn check_provision_dir(config: Option<&Config>) -> Result<(), Error> {
+    let dir = get_provisioning_dir(config);
+    if !dir.exists() {
         fs::create_dir_all(&dir)?;
-        tracing::info!("Created provisioning directory: {}", &dir);
+        tracing::info!("Created provisioning directory: {}", dir.display());
     }
     Ok(())
 }
 
 /// Determines if VM is a gen1 or gen2 based on EFI detection,
 /// Returns `true` if it is a Gen1 VM (i.e., not UEFI/Gen2).
-fn is_vm_gen1() -> bool {
-    if Path::new("/sys/firmware/efi").exists() {
-        return false;
+///
+/// # Parameters:
+/// - `mock_efi_path` (optional): Used in **tests** to override the default EFI detection path.
+///   - If provided, the function checks if the file exists:
+///     - If **the file exists**, it simulates Gen2 (`false`).
+///     - If **the file does not exist**, it simulates Gen1 (`true`).
+///   - If `None` is provided, it defaults to **checking real system paths** (`/sys/firmware/efi` and `/dev/efi`).
+fn is_vm_gen1(mock_efi_path: Option<&str>) -> bool {
+    if let Some(path) = mock_efi_path {
+        !Path::new(path).exists()
+    } else {
+        if Path::new("/sys/firmware/efi").exists()
+            || Path::new("/dev/efi").exists()
+        {
+            return false;
+        }
+        true
     }
-    if Path::new("/dev/efi").exists() {
-        return false;
-    }
-    true
 }
 
-/// A helper function that reorders the UUID's first three fields into little-endian.
-// The standard UUID fields are: d1 (4 bytes), d2 (2 bytes), d3 (2 bytes), and d4 (8 bytes).
+/// Converts a UUID from big-endian to little-endian format, as required for Gen1 VMs.
+/// # Swap Behavior:
+/// - The **first three fields** (`d1`, `d2`, `d3`) are **byte-swapped** individually.
+/// - The **last 8 bytes (`d4`) remain unchanged**.
 fn swap_uuid_to_little_endian(bytes: [u8; 16]) -> [u8; 16] {
     let d1 = BigEndian::read_u32(&bytes[0..4]);
     let d2 = BigEndian::read_u16(&bytes[4..6]);
@@ -69,9 +92,17 @@ fn swap_uuid_to_little_endian(bytes: [u8; 16]) -> [u8; 16] {
     let d3_le = d3.swap_bytes();
 
     let mut swapped = [0u8; 16];
-    LittleEndian::write_u32(&mut swapped[0..4], d1_le);
-    LittleEndian::write_u16(&mut swapped[4..6], d2_le);
-    LittleEndian::write_u16(&mut swapped[6..8], d3_le);
+
+    swapped[0] = (d1_le >> 24) as u8;
+    swapped[1] = (d1_le >> 16) as u8;
+    swapped[2] = (d1_le >> 8) as u8;
+    swapped[3] = (d1_le) as u8;
+
+    swapped[4] = (d2_le >> 8) as u8;
+    swapped[5] = (d2_le) as u8;
+
+    swapped[6] = (d3_le >> 8) as u8;
+    swapped[7] = (d3_le) as u8;
 
     swapped[8..16].copy_from_slice(&bytes[8..16]);
 
@@ -86,30 +117,27 @@ fn swap_uuid_to_little_endian(bytes: [u8; 16]) -> [u8; 16] {
 /// # Returns
 /// - `Some(String)` containing the VM ID if retrieval is successful.
 /// - `None` if something fails or the output is empty.
-pub fn get_vm_id() -> Option<String> {
+pub fn get_vm_id(
+    custom_path: Option<&str>,
+    mock_efi_path: Option<&str>,
+) -> Option<String> {
     // Test override check
-    if let Ok(mock_id) = std::env::var("MOCK_VM_ID") {
-        return Some(mock_id);
-    }
+    let path = custom_path.unwrap_or("/sys/class/dmi/id/product_uuid");
 
-    let system_uuid = match fs::read_to_string("/sys/class/dmi/id/product_uuid")
-    {
+    let system_uuid = match fs::read_to_string(path) {
         Ok(s) => s.trim().to_lowercase(),
         Err(err) => {
-            tracing::error!(
-                "Failed to read /sys/class/dmi/id/product_uuid: {}",
-                err
-            );
+            tracing::error!("Failed to read VM ID from {}: {}", path, err);
             return None;
         }
     };
 
     if system_uuid.is_empty() {
-        tracing::info!(target: "libazureinit::status::retrieved_vm_id", "system-uuid is empty");
+        tracing::info!(target: "libazureinit::status::retrieved_vm_id", "VM ID file is empty at path: {}", path);
         return None;
     }
 
-    if is_vm_gen1() {
+    if is_vm_gen1(mock_efi_path) {
         match Uuid::parse_str(&system_uuid) {
             Ok(uuid_parsed) => {
                 let original_bytes = uuid_parsed.as_bytes();
@@ -141,10 +169,15 @@ pub fn get_vm_id() -> Option<String> {
 ///
 /// - Returns `true` if provisioning is complete (i.e., provisioning file exists).
 /// - Returns `false` if provisioning has not been completed (i.e., no provisioning file exists).
-pub fn is_provisioning_complete() -> bool {
-    if let Some(vm_id) = get_vm_id() {
+pub fn is_provisioning_complete(
+    config: Option<&Config>,
+    vm_id: Option<String>,
+) -> bool {
+    let vm_id = vm_id.or_else(|| get_vm_id(None, None));
+
+    if let Some(vm_id) = vm_id {
         let file_path =
-            format!("{}/{}.provisioned", get_provisioning_dir(), vm_id);
+            get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
         if std::path::Path::new(&file_path).exists() {
             tracing::info!("Provisioning already complete. Skipping...");
             return true;
@@ -157,17 +190,22 @@ pub fn is_provisioning_complete() -> bool {
 /// This function creates an empty file named after the current VM ID in the
 /// provisioning directory. The presence of this file signals that provisioning
 /// has been successfully completed.
-pub fn mark_provisioning_complete() -> Result<(), Error> {
-    check_provision_dir()?;
+pub fn mark_provisioning_complete(
+    config: Option<&Config>,
+    vm_id: Option<String>,
+) -> Result<(), Error> {
+    check_provision_dir(config)?;
 
-    if let Some(vm_id) = get_vm_id() {
+    let vm_id = vm_id.or_else(|| get_vm_id(None, None));
+
+    if let Some(vm_id) = vm_id {
         let file_path =
-            format!("{}/{}.provisioned", get_provisioning_dir(), vm_id);
+            get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
 
         if let Err(error) = File::create(&file_path) {
             tracing::error!(
                 ?error,
-                file_path,
+                file_path=?file_path,
                 "Failed to create provisioning status file"
             );
             return Err(error.into());
@@ -176,7 +214,7 @@ pub fn mark_provisioning_complete() -> Result<(), Error> {
         tracing::info!(
             target: "libazureinit::status::success",
             "Provisioning complete. File created: {}",
-            file_path
+            file_path.display()
         );
     }
 
@@ -193,39 +231,44 @@ mod tests {
     fn test_mark_provisioning_complete() {
         let test_dir = TempDir::new().unwrap();
         std::env::set_var(
-            "TEST_PROVISION_DIR",
+            "AZURE_INIT_TEST_PROVISIONING_DIR",
             test_dir.path().to_str().unwrap(),
         );
 
-        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-123");
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440000")
+            .unwrap();
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
 
-        let file_path = test_dir.path().join("FAKE-VM-ID-123.provisioned");
+        let file_path = test_dir.path().join(format!("{}.provisioned", vm_id));
         assert!(
             !file_path.exists(),
             "File should not exist before provisioning"
         );
-        mark_provisioning_complete().unwrap();
+
+        mark_provisioning_complete(None, Some(vm_id.clone())).unwrap();
         assert!(file_path.exists(), "Provisioning file should be created");
     }
-
     #[test]
     fn test_is_provisioning_complete() {
         let test_dir = TempDir::new().unwrap();
         std::env::set_var(
-            "TEST_PROVISION_DIR",
+            "AZURE_INIT_TEST_PROVISIONING_DIR",
             test_dir.path().to_str().unwrap(),
         );
-        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-456");
 
-        assert!(
-            !is_provisioning_complete(),
-            "Provisioning should be needed if file doesn't exist"
-        );
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440001")
+            .unwrap();
 
-        let file_path = test_dir.path().join("FAKE-VM-ID-456.provisioned");
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
+        let file_path = test_dir.path().join(format!("{}.provisioned", vm_id));
         fs::File::create(&file_path).unwrap();
+
         assert!(
-            is_provisioning_complete(),
+            is_provisioning_complete(None, Some(vm_id.clone())),
             "Provisioning should be complete if file exists"
         );
     }
@@ -234,21 +277,66 @@ mod tests {
     fn test_provisioning_skipped_on_simulated_reboot() {
         let test_dir = TempDir::new().unwrap();
         std::env::set_var(
-            "TEST_PROVISION_DIR",
+            "AZURE_INIT_TEST_PROVISIONING_DIR",
             test_dir.path().to_str().unwrap(),
         );
-        std::env::set_var("MOCK_VM_ID", "FAKE-VM-ID-999");
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440002")
+            .unwrap();
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
         assert!(
-            !is_provisioning_complete(),
+            !is_provisioning_complete(None, Some(vm_id.clone())),
             "Should need provisioning initially"
         );
 
-        mark_provisioning_complete().unwrap();
+        mark_provisioning_complete(None, Some(vm_id.clone())).unwrap();
 
         // Simulate a "reboot" by calling again
         assert!(
-            is_provisioning_complete(),
+            is_provisioning_complete(None, Some(vm_id.clone())),
             "Provisioning should be skipped on second run (file exists)"
+        );
+    }
+
+    #[test]
+    fn test_get_vm_id_mocked_gen1_vs_gen2() {
+        let test_dir = TempDir::new().unwrap();
+        std::env::set_var(
+            "AZURE_INIT_TEST_PROVISIONING_DIR",
+            test_dir.path().to_str().unwrap(),
+        );
+
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440000")
+            .unwrap();
+
+        let mock_efi_path = test_dir.path().join("mock_efi_file");
+
+        // Simulate Gen1: don't create the mock EFI file => it doesn't exist => is_vm_gen1() returns true
+        let vm_id_gen1 = get_vm_id(
+            Some(mock_vm_id_path.to_str().unwrap()),
+            Some(mock_efi_path.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            vm_id_gen1, "00840e55-9be2-d441-a716-446655440000",
+            "Should byte-swap for Gen1"
+        );
+
+        // Simulate Gen2: create the mock EFI file => is_vm_gen1() sees it => returns false
+        fs::File::create(&mock_efi_path).unwrap();
+
+        let vm_id_gen2 = get_vm_id(
+            Some(mock_vm_id_path.to_str().unwrap()),
+            Some(mock_efi_path.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            vm_id_gen2, "550e8400-e29b-41d4-a716-446655440000",
+            "Should NOT byte-swap for Gen2"
         );
     }
 }

--- a/libazureinit/src/status.rs
+++ b/libazureinit/src/status.rs
@@ -23,7 +23,7 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-use crate::config::Config;
+use crate::config::{Config, DEFAULT_PROVISIONING_DIR};
 use crate::error::Error;
 
 /// This function determines the effective provisioning directory.
@@ -33,7 +33,7 @@ use crate::error::Error;
 fn get_provisioning_dir(config: Option<&Config>) -> PathBuf {
     config
         .map(|cfg| cfg.provisioning_dir.path.clone())
-        .unwrap_or_else(|| PathBuf::from("/var/lib/azure-init/"))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_PROVISIONING_DIR))
 }
 
 /// This function checks if the provisioning directory is present, and if not,

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -152,7 +152,9 @@ impl EmitKVPLayer {
 
         tokio::spawn(Self::kvp_writer(file, events_rx));
 
-        let vm_id = get_vm_id().unwrap_or_else(|| "unknown-vm-id".to_string());
+        let vm_id: String = get_vm_id(None, None).unwrap_or_else(|| {
+            "00000000-0000-0000-0000-000000000000".to_string()
+        });
 
         Ok(Self { events_tx, vm_id })
     }

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -152,7 +152,7 @@ impl EmitKVPLayer {
 
         tokio::spawn(Self::kvp_writer(file, events_rx));
 
-        let vm_id: String = get_vm_id(None, None).unwrap_or_else(|| {
+        let vm_id: String = get_vm_id().unwrap_or_else(|| {
             "00000000-0000-0000-0000-000000000000".to_string()
         });
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,6 +23,7 @@ pub fn initialize_tracing() -> sdktrace::Tracer {
 
 pub fn setup_layers(
     tracer: sdktrace::Tracer,
+    vm_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let otel_layer = OpenTelemetryLayer::new(tracer)
         .with_filter(EnvFilter::from_env("AZURE_INIT_LOG"));
@@ -43,9 +44,10 @@ pub fn setup_layers(
         .join(","),
     )?;
 
-    let emit_kvp_layer = match EmitKVPLayer::new(std::path::PathBuf::from(
-        "/var/lib/hyperv/.kvp_pool_1",
-    )) {
+    let emit_kvp_layer = match EmitKVPLayer::new(
+        std::path::PathBuf::from("/var/lib/hyperv/.kvp_pool_1"),
+        vm_id,
+    ) {
         Ok(layer) => Some(layer.with_filter(kvp_filter)),
         Err(e) => {
             event!(Level::ERROR, "Failed to initialize EmitKVPLayer: {}. Continuing without KVP logging.", e);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -37,6 +37,7 @@ pub fn setup_layers(
             "libazureinit::ssh::authorized_keys",
             "libazureinit::ssh::success",
             "libazureinit::user::add",
+            "libazureinit::status::success",
         ]
         .join(","),
     )?;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -38,6 +38,7 @@ pub fn setup_layers(
             "libazureinit::ssh::success",
             "libazureinit::user::add",
             "libazureinit::status::success",
+            "libazureinit::status::retrieved_vm_id",
         ]
         .join(","),
     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use libazureinit::{
     reqwest::{header, Client},
     Provision,
 };
-use libazureinit::{is_provisioning_complete, mark_provisioning_complete};
+use libazureinit::{
+    get_vm_id, is_provisioning_complete, mark_provisioning_complete,
+};
 use std::process::ExitCode;
 use std::time::Duration;
 use sysinfo::System;
@@ -100,8 +102,10 @@ fn get_username(
 #[tokio::main]
 async fn main() -> ExitCode {
     let tracer = initialize_tracing();
+    let vm_id: String = get_vm_id()
+        .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
 
-    if let Err(e) = setup_layers(tracer) {
+    if let Err(e) = setup_layers(tracer, &vm_id) {
         eprintln!("Warning: Failed to set up tracing layers: {:?}", e);
     }
 
@@ -116,14 +120,14 @@ async fn main() -> ExitCode {
         }
     };
 
-    if is_provisioning_complete(Some(&config)) {
+    if is_provisioning_complete(Some(&config), &vm_id) {
         tracing::info!(
             "Provisioning already completed earlier. Skipping provisioning."
         );
         return ExitCode::SUCCESS;
     }
 
-    match provision(config, opts).await {
+    match provision(config, &vm_id, opts).await {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("Provisioning failed with error: {:?}", e);
@@ -143,7 +147,11 @@ async fn main() -> ExitCode {
 }
 
 #[instrument(name = "root", skip_all)]
-async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
+async fn provision(
+    config: Config,
+    vm_id: &str,
+    opts: Cli,
+) -> Result<(), anyhow::Error> {
     let kernel_version = System::kernel_version()
         .unwrap_or("Unknown Kernel Version".to_string());
     let os_version =
@@ -230,10 +238,12 @@ async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
         "Failed to report VM health."
     })?;
 
-    mark_provisioning_complete(Some(&clone_config)).with_context(|| {
-        tracing::error!("Failed to mark provisioning complete.");
-        "Failed to mark provisioning complete."
-    })?;
+    mark_provisioning_complete(Some(&clone_config), vm_id).with_context(
+        || {
+            tracing::error!("Failed to mark provisioning complete.");
+            "Failed to mark provisioning complete."
+        },
+    )?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,14 +116,19 @@ async fn main() -> ExitCode {
         }
     };
 
-    if is_provisioning_complete() {
-        tracing::info!("Provisioning already complete. Exiting...");
+    if is_provisioning_complete(Some(&config), None) {
+        tracing::info!(
+            "Provisioning already completed earlier. Skipping provisioning."
+        );
         return ExitCode::SUCCESS;
     }
 
+    let clone_config = config.clone();
     match provision(config, opts).await {
         Ok(_) => {
-            if let Err(e) = mark_provisioning_complete() {
+            if let Err(e) =
+                mark_provisioning_complete(Some(&clone_config), None)
+            {
                 tracing::error!(
                     "Failed to mark provisioning as complete: {:?}",
                     e

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> ExitCode {
         }
     };
 
-    if is_provisioning_complete(Some(&config), None) {
+    if is_provisioning_complete(Some(&config)) {
         tracing::info!(
             "Provisioning already completed earlier. Skipping provisioning."
         );
@@ -230,12 +230,10 @@ async fn provision(config: Config, opts: Cli) -> Result<(), anyhow::Error> {
         "Failed to report VM health."
     })?;
 
-    mark_provisioning_complete(Some(&clone_config), None).with_context(
-        || {
-            tracing::error!("Failed to mark provisioning complete.");
-            "Failed to mark provisioning complete."
-        },
-    )?;
+    mark_provisioning_complete(Some(&clone_config)).with_context(|| {
+        tracing::error!("Failed to mark provisioning complete.");
+        "Failed to mark provisioning complete."
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new `status.rs` module that helps manage the **provisioning lifecycle** for Azure Linux VMs.  
The core idea is to **create and check** a `.provisioned` file named after the VM ID when provisioning is completed, ensuring we skip provisioning on reboot if the file already exists. Additionally, this file can serve as an indicator that provisioning has been completed.

---

## Key Points

### **Provisioning File Logic**
- We now store a file at `\{provision_dir}/{vm_id}.provisioned`.
- If the file exists, provisioning is **considered complete**; otherwise, we run provisioning.
- The provisioning directory is configurable through `Config.provisioning_dir` and defaults to `/var/lib/azure-init/`.


### **VM ID Retrieval**
- Production retrieves the VM ID by reading `/sys/class/dmi/id/product_uuid` and byte-swapping if Gen1.
- `is_vm_gen1()` accepts a mock EFI path, allowing test scenarios to simulate different VM generations without relying on actual system files.

### **Integration with `main.rs`**
- `main.rs` checks `is_provisioning_complete()` to see if it needs to run provisioning.
- After successful provisioning, `mark_provisioning_complete()` creates the `.provisioned` file.
- On subsequent boots, if the file is found, provisioning is skipped.
- Additionally, main.rs retrieves the `vm_id` once and passes it through all necessary functions.

### **Unit Test Setup**
- **Environment variables** drive our partial mocking in tests:
  - `TEST_PROVISION_DIR` → points to a `TempDir` instead of `/var/lib/azure-init/`.
  -  tests pass an explicit file path for VM ID retrieval.

- **Tests verify** that:
  - **First run**: no provisioning file → provisioning needed.
  - **File is created**: `mark_provisioning_complete()` actually writes the file.
  - **Subsequent runs**: the `.provisioned` file is detected, so provisioning is skipped (simulated reboot test).


- **Linked Issues**:
  - Resolves #120 
  - Step 1 in integrating `azure-init` with WALinuxAgent