### PR TITLE
Update opentelemetry(_sdk) to 0.28, tracing-opentelemetry 0.29, fix build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.27"
+opentelemetry = "0.28"
 opentelemetry_sdk = "0.27"
 tracing-opentelemetry = "0.28"
 uuid = { version = "1.2", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.28"
 opentelemetry_sdk = "0.28"
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = "0.29"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.28"
-opentelemetry_sdk = "0.27"
+opentelemetry_sdk = "0.28"
 tracing-opentelemetry = "0.28"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 use opentelemetry::{global, trace::TracerProvider};
-use opentelemetry_sdk::trace::{
-    self as sdktrace, Sampler, TracerProvider as SdkTracerProvider,
-};
+use opentelemetry_sdk::trace::{self as sdktrace, Sampler, SdkTracerProvider};
 use tracing::{event, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::fmt::format::FmtSpan;


### PR DESCRIPTION
Update `opentelemetry` & `opentelemetry_sdk` to 0.28, `tracing-opentelemetry` to 0.29.
(Replaces https://github.com/Azure/azure-init/pull/162, https://github.com/Azure/azure-init/pull/163, https://github.com/Azure/azure-init/pull/166)

Now that `opentelemetry_sdk` 0.28 renamed `TracerProvider` to `SdkTraceProvider`, we need to update use cases in logging.
See also https://github.com/open-telemetry/opentelemetry-rust/pull/2614.


