### PR TITLE
Output `azure-init.log` to Configurable Location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.27"
-opentelemetry_sdk = "0.27"
-tracing-opentelemetry = "0.28"
+opentelemetry = "0.28"
+opentelemetry_sdk = "0.28"
+tracing-opentelemetry = "0.29"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"
 

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.8"
 regex = "1"
 lazy_static = "1.4"
 figment = { version = "0.10", features = ["toml"] }
+uuid = "1.3"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 pub mod config;
-pub use config::{HostnameProvisioner, PasswordProvisioner, UserProvisioner};
+pub use config::{
+    HostnameProvisioner, PasswordProvisioner, UserProvisioner,
+    DEFAULT_TELEMETRY_LOG_PATH,
+};
 pub mod error;
 pub mod goalstate;
 pub(crate) mod http;
@@ -10,6 +13,10 @@ pub mod media;
 
 mod provision;
 pub use provision::{user::User, Provision};
+mod status;
+pub use status::{
+    get_vm_id, is_provisioning_complete, mark_provisioning_complete,
+};
 
 #[cfg(test)]
 mod unittest;

--- a/libazureinit/src/status.rs
+++ b/libazureinit/src/status.rs
@@ -1,0 +1,337 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Provisioning status management for azure-init.
+//!
+//! This module ensures that provisioning is performed only when necessary
+//! by tracking the VM ID. It stores a provisioning status file named after
+//! the VM ID in a persistent location (`/var/lib/azure-init/`).
+//!
+//! # Logic Overview
+//! - Retrieves the VM ID using reading `/sys/class/dmi/id/product_uuid` and byte-swapping if Gen1 VM.
+//! - Determines if provisioning is required by checking if a status file exists.
+//! - The provisioning directory is configurable via the Config struct (defaulting to `/var/lib/azure-init/`).
+//! - Creates the provisioning status file upon successful provisioning.
+//! - Prevents unnecessary re-provisioning on reboot, unless the VM ID changes.
+//!
+//! # Behavior
+//! - On **first boot**, provisioning runs and a file is created: `/var/lib/azure-init/{vm_id}`
+//! - On **reboot**, if the same VM ID exists, provisioning is skipped.
+//! - If the **VM ID changes** (e.g., due to VM cloning), provisioning runs again.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+use crate::config::{Config, DEFAULT_PROVISIONING_DIR};
+use crate::error::Error;
+
+/// This function determines the effective provisioning directory.
+///
+/// If a [`Config`] is provided, this function returns `config.provisioning_dir.path`.
+/// Otherwise, it falls back to the default `/var/lib/azure-init/`.
+fn get_provisioning_dir(config: Option<&Config>) -> PathBuf {
+    config
+        .map(|cfg| cfg.provisioning_dir.path.clone())
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_PROVISIONING_DIR))
+}
+
+/// This function checks if the provisioning directory is present, and if not,
+/// it creates it.
+fn check_provision_dir(config: Option<&Config>) -> Result<(), Error> {
+    let dir = get_provisioning_dir(config);
+    if !dir.exists() {
+        fs::create_dir_all(&dir)?;
+        tracing::info!("Created provisioning directory: {}", dir.display());
+    }
+    Ok(())
+}
+
+/// Determines if VM is a gen1 or gen2 based on EFI detection,
+/// Returns `true` if it is a Gen1 VM (i.e., not UEFI/Gen2).
+///
+/// # Parameters:
+/// - `mock_efi_path` (optional): Used in **tests** to override the default EFI detection path.
+///   - If provided, the function checks if the file exists:
+///     - If **the file exists**, it simulates Gen2 (`false`).
+///     - If **the file does not exist**, it simulates Gen1 (`true`).
+///   - If `None` is provided, it defaults to **checking real system paths** (`/sys/firmware/efi` and `/dev/efi`).
+fn is_vm_gen1(mock_efi_path: Option<&str>) -> bool {
+    if let Some(path) = mock_efi_path {
+        !Path::new(path).exists()
+    } else {
+        if Path::new("/sys/firmware/efi").exists()
+            || Path::new("/dev/efi").exists()
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// Converts the first three fields of a 16-byte array from big-endian to
+/// the native endianness, then returns it as a `Uuid`.
+///
+/// This partially swaps the UUID so that d1 (4 bytes), d2 (2 bytes), and d3 (2 bytes)
+/// are converted from big-endian to the local endianness, leaving the final 8 bytes as-is.
+fn swap_uuid_to_little_endian(mut bytes: [u8; 16]) -> Uuid {
+    let (d1, remainder) = bytes.split_at(std::mem::size_of::<u32>());
+    let d1 = d1
+        .try_into()
+        .map(u32::from_be_bytes)
+        .unwrap_or(0)
+        .to_ne_bytes();
+
+    let (d2, remainder) = remainder.split_at(std::mem::size_of::<u16>());
+    let d2 = d2
+        .try_into()
+        .map(u16::from_be_bytes)
+        .unwrap_or(0)
+        .to_ne_bytes();
+
+    let (d3, _) = remainder.split_at(std::mem::size_of::<u16>());
+    let d3 = d3
+        .try_into()
+        .map(u16::from_be_bytes)
+        .unwrap_or(0)
+        .to_ne_bytes();
+
+    let native_endian = d1.into_iter().chain(d2).chain(d3).collect::<Vec<_>>();
+    debug_assert_eq!(native_endian.len(), 8);
+    bytes[..native_endian.len()].copy_from_slice(&native_endian);
+    uuid::Uuid::from_bytes(bytes)
+}
+
+/// Retrieves the VM ID by reading `/sys/class/dmi/id/product_uuid` and byte-swapping if Gen1.
+///
+/// The VM ID is a unique system identifier that persists across reboots but changes
+/// when a VM is cloned or redeployed.
+///
+/// # Returns
+/// - `Some(String)` containing the VM ID if retrieval is successful.
+/// - `None` if something fails or the output is empty.
+pub fn get_vm_id(
+    custom_path: Option<&str>,
+    mock_efi_path: Option<&str>,
+) -> Option<String> {
+    // Test override check
+    let path = custom_path.unwrap_or("/sys/class/dmi/id/product_uuid");
+
+    let system_uuid = match fs::read_to_string(path) {
+        Ok(s) => s.trim().to_lowercase(),
+        Err(err) => {
+            tracing::error!("Failed to read VM ID from {}: {}", path, err);
+            return None;
+        }
+    };
+
+    if system_uuid.is_empty() {
+        tracing::info!(target: "libazureinit::status::retrieved_vm_id", "VM ID file is empty at path: {}", path);
+        return None;
+    }
+
+    if is_vm_gen1(mock_efi_path) {
+        match Uuid::parse_str(&system_uuid) {
+            Ok(uuid_parsed) => {
+                let swapped_uuid =
+                    swap_uuid_to_little_endian(*uuid_parsed.as_bytes());
+                let final_id = swapped_uuid.to_string();
+                tracing::info!(target: "libazureinit::status::retrieved_vm_id", "VM ID (Gen1, swapped): {}", final_id);
+                Some(final_id)
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to parse system UUID '{}': {}",
+                    system_uuid,
+                    e
+                );
+                // fallback to the raw string
+                Some(system_uuid)
+            }
+        }
+    } else {
+        tracing::info!(target: "libazureinit::status::retrieved_vm_id", "VM ID (Gen2, no swap): {}", system_uuid);
+        Some(system_uuid)
+    }
+}
+
+/// This function checks whether a provisioning status file exists for the current VM ID.
+/// If the file exists, provisioning has already been completed and should be skipped.
+/// If the file does not exist or the VM ID has changed, provisioning should proceed.
+///
+/// - Returns `true` if provisioning is complete (i.e., provisioning file exists).
+/// - Returns `false` if provisioning has not been completed (i.e., no provisioning file exists).
+pub fn is_provisioning_complete(
+    config: Option<&Config>,
+    vm_id: Option<String>,
+) -> bool {
+    let vm_id = vm_id.or_else(|| get_vm_id(None, None));
+
+    if let Some(vm_id) = vm_id {
+        let file_path =
+            get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
+        if std::path::Path::new(&file_path).exists() {
+            tracing::info!("Provisioning already complete. Skipping...");
+            return true;
+        }
+    }
+    tracing::info!("Provisioning required.");
+    false
+}
+
+/// This function creates an empty file named after the current VM ID in the
+/// provisioning directory. The presence of this file signals that provisioning
+/// has been successfully completed.
+pub fn mark_provisioning_complete(
+    config: Option<&Config>,
+    vm_id: Option<String>,
+) -> Result<(), Error> {
+    check_provision_dir(config)?;
+
+    let vm_id = vm_id.or_else(|| get_vm_id(None, None));
+
+    if let Some(vm_id) = vm_id {
+        let file_path =
+            get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
+
+        if let Err(error) = File::create(&file_path) {
+            tracing::error!(
+                ?error,
+                file_path=?file_path,
+                "Failed to create provisioning status file"
+            );
+            return Err(error.into());
+        }
+
+        tracing::info!(
+            target: "libazureinit::status::success",
+            "Provisioning complete. File created: {}",
+            file_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Creates a temporary directory and returns a default `Config`
+    /// whose `provisioning_dir` points to that temp directory.
+    /// Also returns the `TempDir` so it remains in scope for the test.
+    fn create_test_config() -> (Config, TempDir) {
+        let test_dir = TempDir::new().unwrap();
+
+        let mut test_config = Config::default();
+        test_config.provisioning_dir.path = test_dir.path().to_path_buf();
+
+        (test_config, test_dir)
+    }
+
+    #[test]
+    fn test_mark_provisioning_complete() {
+        let (test_config, test_dir) = create_test_config();
+
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440000")
+            .unwrap();
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
+
+        let file_path = test_dir.path().join(format!("{}.provisioned", vm_id));
+        assert!(
+            !file_path.exists(),
+            "File should not exist before provisioning"
+        );
+
+        mark_provisioning_complete(Some(&test_config), Some(vm_id.clone()))
+            .unwrap();
+        assert!(file_path.exists(), "Provisioning file should be created");
+    }
+
+    #[test]
+    fn test_is_provisioning_complete() {
+        let (test_config, test_dir) = create_test_config();
+
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440001")
+            .unwrap();
+
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
+
+        let file_path = test_dir.path().join(format!("{}.provisioned", vm_id));
+        fs::File::create(&file_path).unwrap();
+
+        assert!(
+            is_provisioning_complete(Some(&test_config), Some(vm_id.clone())),
+            "Provisioning should be complete if file exists"
+        );
+    }
+
+    #[test]
+    fn test_provisioning_skipped_on_simulated_reboot() {
+        let (test_config, test_dir) = create_test_config();
+
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440002")
+            .unwrap();
+
+        let vm_id =
+            get_vm_id(Some(mock_vm_id_path.to_str().unwrap()), None).unwrap();
+
+        assert!(
+            !is_provisioning_complete(Some(&test_config), Some(vm_id.clone())),
+            "Should need provisioning initially"
+        );
+
+        mark_provisioning_complete(Some(&test_config), Some(vm_id.clone()))
+            .unwrap();
+
+        // Simulate a "reboot" by calling again
+        assert!(
+            is_provisioning_complete(Some(&test_config), Some(vm_id.clone())),
+            "Provisioning should be skipped on second run (file exists)"
+        );
+    }
+
+    #[test]
+    fn test_get_vm_id_mocked_gen1_vs_gen2() {
+        let test_dir = TempDir::new().unwrap();
+
+        let mock_vm_id_path = test_dir.path().join("mock_product_uuid");
+        fs::write(&mock_vm_id_path, "550e8400-e29b-41d4-a716-446655440000")
+            .unwrap();
+
+        let mock_efi_path = test_dir.path().join("mock_efi_file");
+
+        // Simulate Gen1: don't create the mock EFI file => it doesn't exist => is_vm_gen1() returns true
+        let vm_id_gen1 = get_vm_id(
+            Some(mock_vm_id_path.to_str().unwrap()),
+            Some(mock_efi_path.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            vm_id_gen1, "00840e55-9be2-d441-a716-446655440000",
+            "Should byte-swap for Gen1"
+        );
+
+        // Simulate Gen2: create the mock EFI file => is_vm_gen1() sees it => returns false
+        fs::File::create(&mock_efi_path).unwrap();
+
+        let vm_id_gen2 = get_vm_id(
+            Some(mock_vm_id_path.to_str().unwrap()),
+            Some(mock_efi_path.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            vm_id_gen2, "550e8400-e29b-41d4-a716-446655440000",
+            "Should NOT byte-swap for Gen2"
+        );
+    }
+}

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -37,6 +37,8 @@ use chrono::{DateTime, Utc};
 use std::fmt;
 use uuid::Uuid;
 
+use libazureinit::get_vm_id;
+
 const HV_KVP_EXCHANGE_MAX_KEY_SIZE: usize = 512;
 const HV_KVP_EXCHANGE_MAX_VALUE_SIZE: usize = 2048;
 const HV_KVP_AZURE_MAX_VALUE_SIZE: usize = 1022;
@@ -125,6 +127,7 @@ impl fmt::Display for SpanStatus {
 /// task, and provides functions to send encoded data for logging.
 pub struct EmitKVPLayer {
     events_tx: UnboundedSender<Vec<u8>>,
+    vm_id: String,
 }
 
 impl EmitKVPLayer {
@@ -149,7 +152,11 @@ impl EmitKVPLayer {
 
         tokio::spawn(Self::kvp_writer(file, events_rx));
 
-        Ok(Self { events_tx })
+        let vm_id: String = get_vm_id(None, None).unwrap_or_else(|| {
+            "00000000-0000-0000-0000-000000000000".to_string()
+        });
+
+        Ok(Self { events_tx, vm_id })
     }
 
     /// An asynchronous task that serializes incoming KVP data to the specified file.
@@ -192,7 +199,8 @@ impl EmitKVPLayer {
         span_id: &str,
         event_value: &str,
     ) {
-        let event_key = generate_event_key(event_level, event_name, span_id);
+        let event_key =
+            generate_event_key(&self.vm_id, event_level, event_name, span_id);
         let encoded_kvp = encode_kvp_item(&event_key, event_value);
         let encoded_kvp_flattened: Vec<u8> = encoded_kvp.concat();
         self.send_event(encoded_kvp_flattened);
@@ -338,13 +346,14 @@ where
 /// * `event_name` - The name of the event.
 /// * `span_id` - A unique identifier for the span.
 fn generate_event_key(
+    vm_id: &str,
     event_level: &str,
     event_name: &str,
     span_id: &str,
 ) -> String {
     format!(
-        "{}|{}|{}|{}",
-        EVENT_PREFIX, event_level, event_name, span_id
+        "{}|{}|{}|{}|{}",
+        EVENT_PREFIX, vm_id, event_level, event_name, span_id
     )
 }
 


### PR DESCRIPTION
This PR makes the `azure-init log` path configurable via the `Config` struct while ensuring logging is properly initialized before configuration is loaded. 

To achieve this, the logging setup now follows a two-phase approach:
- Phase 1 (Minimal Logging Pre-Config)
 -- Initializes tracing with console (`stderr`), KVP (Hyper-V), and OpenTelemetry logging.
-- This ensures that logs from early configuration loading are captured.
- Phase 2 (Full Logging with Config)
-- Once `Config` is available, logging is reconfigured to also write to the configured `telemetry_log_path.`
-- The file path is taken from `config.telemetry_log_path`, falling back to `DEFAULT_TELEMETRY_LOG_PATH` if unspecified.


This PR relies on #164 to be merged first, because the azure-init.log was used to test the functionality of that PR. 