### PR TITLE
deps: pin zerofrom to 0.1.5 and litemap to 0.7.4

### DIFF
--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -24,6 +24,14 @@ toml = "0.8"
 regex = "1"
 lazy_static = "1.4"
 figment = { version = "0.10", features = ["toml"] }
+# Pinned to 0.1.5 since 0.1.6 bumps its MSRV to 1.81.
+# The major difference in 0.1.6 is the switch to core::error
+# This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
+zerofrom = "=0.1.5"
+# Pinned to 0.7.4 since 0.7.5 bumps its MSRV to 1.81.
+# The major difference in 0.7.5 is the switch to core::error; there's also a few API additions.
+# This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
+litemap = "=0.7.4"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }


### PR DESCRIPTION
zerofrom and litemap both bumped their MSRV to 1.81 in recent releases.
These are both transitive dependencies so it's possible in the future
our dependencies will drop them, so we will need to occasionally check
on that.

As our current MSRV policy is to support Rust from about a year ago, we
can unpin these around September 5th, 2025.

Although neither crate has a changelog, looking at the git history
indicates there's minimal changes other than the switch to core::error
(which is what requires 1.81). zerofrom has a few adjustments for new
lints, and litemap introduces a new API (which hopefully none of our
dependencies start requiring).

This should fix the CI failures in #164 