### PR TITLE
Output `azure-init.log` to Configurable Location

### DIFF
--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -252,23 +252,23 @@ impl Default for AzureInitDataDir {
 }
 
 /// The default directory for azure-init.log
-pub const DEFAULT_TELEMETRY_LOG_PATH: &str = "/var/log/azure-init.log";
+pub const DEFAULT_AZURE_INIT_LOG_PATH: &str = "/var/log/azure-init.log";
 /// Telemetry log (azure-init.log) struct.
 /// Configures settings for where azure-init should channel telemetry logs.
-/// If no custom path is provided, `TelemetryLogPath::default()` uses
-/// [`DEFAULT_TELEMETRY_LOG_PATH`].
+/// If no custom path is provided, `AzureInitLogPath ::default()` uses
+/// [`DEFAULT_AZURE_INIT_LOG_PATH`].
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct TelemetryLogPath {
+pub struct AzureInitLogPath {
     /// Specifies the path used to capture all telemetry logs.
     /// Defaults to `/var/log/azure-init.log`.
     pub path: PathBuf,
 }
 
-impl Default for TelemetryLogPath {
+impl Default for AzureInitLogPath {
     fn default() -> Self {
         Self {
-            path: PathBuf::from(DEFAULT_TELEMETRY_LOG_PATH),
+            path: PathBuf::from(DEFAULT_AZURE_INIT_LOG_PATH),
         }
     }
 }
@@ -290,7 +290,7 @@ pub struct Config {
     pub wireserver: Wireserver,
     pub telemetry: Telemetry,
     pub azure_init_data_dir: AzureInitDataDir,
-    pub telemetry_log_path: TelemetryLogPath,
+    pub azure_init_log_path: AzureInitLogPath,
 }
 
 /// Implements `Display` for `Config`, formatting it as a readable TOML string.
@@ -654,7 +654,7 @@ mod tests {
         );
 
         assert_eq!(
-            config.telemetry_log_path.path.to_str().unwrap(),
+            config.azure_init_log_path.path.to_str().unwrap(),
             "/var/log/azure-init.log"
         );
 
@@ -693,7 +693,7 @@ mod tests {
         kvp_diagnostics = false
         [azure_init_data_dir]
         path = "/custom/azure-init-data-dir"
-        [telemetry_log_path]
+        [azure_init_log_path]
         path = "/custom/path/azure-init.log"
         "#
         )?;
@@ -761,7 +761,7 @@ mod tests {
 
         tracing::debug!("Verifying merged telemetry log path configuration...");
         assert_eq!(
-            config.telemetry_log_path.path.to_str().unwrap(),
+            config.azure_init_log_path.path.to_str().unwrap(),
             "/custom/path/azure-init.log"
         );
 
@@ -839,7 +839,7 @@ mod tests {
 
         tracing::debug!("Verifying merged telemetry log path configuration...");
         assert_eq!(
-            config.telemetry_log_path.path.to_str().unwrap(),
+            config.azure_init_log_path.path.to_str().unwrap(),
             "/var/log/azure-init.log"
         );
 
@@ -875,7 +875,7 @@ mod tests {
         kvp_diagnostics = false
         [azure_init_data_dir]
         path = "/cli-override-azure-init-data-dir"
-        [telemetry_log_path]
+        [azure_init_log_path]
         path = "/custom/path/azure-init.log"
         "#,
         )?;
@@ -924,7 +924,7 @@ mod tests {
             "/cli-override-azure-init-data-dir"
         );
         assert_eq!(
-            config.telemetry_log_path.path.to_str().unwrap(),
+            config.azure_init_log_path.path.to_str().unwrap(),
             "/custom/path/azure-init.log"
         );
 

--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -253,6 +253,7 @@ impl Default for AzureInitDataDir {
 
 /// The default directory for azure-init.log
 pub const DEFAULT_AZURE_INIT_LOG_PATH: &str = "/var/log/azure-init.log";
+
 /// Telemetry log (azure-init.log) struct.
 /// Configures settings for where azure-init should channel telemetry logs.
 /// If no custom path is provided, `AzureInitLogPath ::default()` uses

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -105,46 +105,12 @@ pub fn setup_layers(
         Err(e) => {
             event!(
                 Level::ERROR,
-                "Could not open {}: {}. Falling back to default log path {}.",
+                "Could not open configured log file {}: {}. Continuing without file logging.",
                 log_path.display(),
-                e,
-                DEFAULT_AZURE_INIT_LOG_PATH
+                e
             );
 
-            match OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(DEFAULT_AZURE_INIT_LOG_PATH)
-            {
-                Ok(file) => {
-                    if let Err(e) =
-                        file.set_permissions(Permissions::from_mode(0o600))
-                    {
-                        event!(
-                            Level::WARN,
-                            "Failed to set permissions on {}: {}.",
-                            DEFAULT_AZURE_INIT_LOG_PATH,
-                            e
-                        );
-                    }
-
-                    Some(
-                        fmt::layer()
-                            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-                            .with_writer(file)
-                            .with_filter(EnvFilter::from_env("AZURE_INIT_LOG")),
-                    )
-                }
-                Err(e) => {
-                    event!(
-                            Level::ERROR,
-                            "Could not open default log path {}: {}. Continuing without file logging.",
-                            DEFAULT_AZURE_INIT_LOG_PATH,
-                            e
-                        );
-                    None
-                }
-            }
+            None
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> ExitCode {
     let vm_id: String = get_vm_id()
         .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
 
-    if let Err(e) = setup_layers(tracer, &vm_id) {
+    if let Err(e) = setup_layers(tracer.clone(), &vm_id, None) {
         eprintln!("Warning: Failed to set up tracing layers: {:?}", e);
     }
 
@@ -119,6 +119,10 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+
+    if let Err(e) = setup_layers(tracer, &vm_id, Some(&config)) {
+        tracing::error!("Failed to set final logging subscriber: {e:?}");
+    }
 
     if is_provisioning_complete(Some(&config), &vm_id) {
         tracing::info!(


### PR DESCRIPTION
This PR makes the `azure-init log` path configurable via the `Config` struct while ensuring logging is properly initialized before configuration is loaded. 

To achieve this, the logging setup now follows a two-phase approach:
- Phase 1 (Minimal Logging Pre-Config)
 -- Initializes tracing with console (`stderr`), KVP (Hyper-V), and OpenTelemetry logging.
-- This ensures that logs from early configuration loading are captured.
- Phase 2 (Full Logging with Config)
-- Once `Config` is available, logging is reconfigured to also write to the configured `telemetry_log_path.`
-- The file path is taken from `config.telemetry_log_path`, falling back to `DEFAULT_TELEMETRY_LOG_PATH` if unspecified.


Resolves #64.