### PR TITLE
.github: ignore automatic updates of litemap and zerofrom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "assert_cmd"
-        # stay with <= 2.0.13 for Rust 1.71
-      - dependency-name: "clap"
-        # stay with <= 4.4 for Rust 1.71
-      - dependency-name: "predicates"
-        # stay with <= 3.1.0 for Rust 1.71
-      - dependency-name: "predicates-core"
-        # stay with <= 1.0.6 for Rust 1.71
-      - dependency-name: "predicates-tree"
-        # stay with <= 1.0.9 for Rust 1.71
+      - dependency-name: "litemap"
+        # stay with <= 0.7.4 for Rust 1.76
+      - dependency-name: "zerofrom"
+        # stay with <= 0.1.5 for Rust 1.76


### PR DESCRIPTION
Ignore automatic updates of litemap and zerofrom, to make it compatible with recent changes in https://github.com/Azure/azure-init/pull/173.

Clean up unnecessary ignore rules.
