### PR TITLE
Allow for Enabling/Disabling KVP using Config

### DIFF
--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -251,6 +251,29 @@ impl Default for AzureInitDataDir {
     }
 }
 
+/// The default directory for azure-init.log
+pub const DEFAULT_AZURE_INIT_LOG_PATH: &str = "/var/log/azure-init.log";
+
+/// Telemetry log (azure-init.log) struct.
+/// Configures settings for where azure-init should channel telemetry logs.
+/// If no custom path is provided, `AzureInitLogPath ::default()` uses
+/// [`DEFAULT_AZURE_INIT_LOG_PATH`].
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct AzureInitLogPath {
+    /// Specifies the path used to capture all telemetry logs.
+    /// Defaults to `/var/log/azure-init.log`.
+    pub path: PathBuf,
+}
+
+impl Default for AzureInitLogPath {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from(DEFAULT_AZURE_INIT_LOG_PATH),
+        }
+    }
+}
+
 /// General configuration struct for azure-init.
 ///
 /// Aggregates all configuration settings for managing SSH, provisioning, IMDS, media,
@@ -268,6 +291,7 @@ pub struct Config {
     pub wireserver: Wireserver,
     pub telemetry: Telemetry,
     pub azure_init_data_dir: AzureInitDataDir,
+    pub azure_init_log_path: AzureInitLogPath,
 }
 
 /// Implements `Display` for `Config`, formatting it as a readable TOML string.
@@ -630,6 +654,11 @@ mod tests {
             "/var/lib/azure-init/",
         );
 
+        assert_eq!(
+            config.azure_init_log_path.path.to_str().unwrap(),
+            "/var/log/azure-init.log"
+        );
+
         tracing::debug!("test_empty_config_file_uses_defaults_when_merged completed successfully.");
 
         Ok(())
@@ -665,6 +694,8 @@ mod tests {
         kvp_diagnostics = false
         [azure_init_data_dir]
         path = "/custom/azure-init-data-dir"
+        [azure_init_log_path]
+        path = "/custom/path/azure-init.log"
         "#
         )?;
 
@@ -727,6 +758,12 @@ mod tests {
         assert_eq!(
             config.azure_init_data_dir.path.to_str().unwrap(),
             "/custom/azure-init-data-dir"
+        );
+
+        tracing::debug!("Verifying merged telemetry log path configuration...");
+        assert_eq!(
+            config.azure_init_log_path.path.to_str().unwrap(),
+            "/custom/path/azure-init.log"
         );
 
         tracing::debug!(
@@ -801,6 +838,12 @@ mod tests {
             "/var/lib/azure-init/"
         );
 
+        tracing::debug!("Verifying merged telemetry log path configuration...");
+        assert_eq!(
+            config.azure_init_log_path.path.to_str().unwrap(),
+            "/var/log/azure-init.log"
+        );
+
         tracing::debug!("test_default_config completed successfully.");
 
         Ok(())
@@ -833,6 +876,8 @@ mod tests {
         kvp_diagnostics = false
         [azure_init_data_dir]
         path = "/cli-override-azure-init-data-dir"
+        [azure_init_log_path]
+        path = "/custom/path/azure-init.log"
         "#,
         )?;
 
@@ -878,6 +923,10 @@ mod tests {
         assert_eq!(
             config.azure_init_data_dir.path.to_str().unwrap(),
             "/cli-override-azure-init-data-dir"
+        );
+        assert_eq!(
+            config.azure_init_log_path.path.to_str().unwrap(),
+            "/custom/path/azure-init.log"
         );
 
         Ok(())

--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -256,7 +256,7 @@ pub const DEFAULT_AZURE_INIT_LOG_PATH: &str = "/var/log/azure-init.log";
 
 /// Telemetry log (azure-init.log) struct.
 /// Configures settings for where azure-init should channel telemetry logs.
-/// If no custom path is provided, `AzureInitLogPath ::default()` uses
+/// If no custom path is provided, `AzureInitLogPath::default()` uses
 /// [`DEFAULT_AZURE_INIT_LOG_PATH`].
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -77,7 +77,7 @@ pub fn setup_layers(
     } else {
         event!(
             Level::INFO,
-            "KVP diagnostics are disabled via config. Skipping KVP logging."
+            "Hyper-V KVP diagnostics are disabled via config.  It is recommended to be enabled for support purposes."
         );
         None
     };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,6 +3,9 @@
 
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_sdk::trace::{self as sdktrace, Sampler, SdkTracerProvider};
+use std::fs::{OpenOptions, Permissions};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 use tracing::{event, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -11,6 +14,7 @@ use tracing_subscriber::{
 };
 
 use crate::kvp::EmitKVPLayer;
+use libazureinit::config::{Config, DEFAULT_AZURE_INIT_LOG_PATH};
 
 pub fn initialize_tracing() -> sdktrace::Tracer {
     let provider = SdkTracerProvider::builder()
@@ -21,9 +25,20 @@ pub fn initialize_tracing() -> sdktrace::Tracer {
     provider.tracer("azure-kvp")
 }
 
+/// Builds a `tracing` subscriber that can optionally write azure-init.log
+/// to a specific location if `Some(&Config)` is provided.
+///
+/// This function follows a two-phase initialization:
+/// - Minimal Setup (Pre-Config): When called initially, it sets up basic logging
+///   to console (`stderr`), KVP (Hyper-V), and OpenTelemetry without file logging.
+///
+/// - Full Setup (Post-Config): After the configuration is loaded, it is called again
+///   with `config`, adding file logging to `config.azure_init_log_path.path` or
+///   falling back to `DEFAULT_AZURE_INIT_LOG_PATH` if unspecified.
 pub fn setup_layers(
     tracer: sdktrace::Tracer,
     vm_id: &str,
+    config: Option<&Config>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let otel_layer = OpenTelemetryLayer::new(tracer)
         .with_filter(EnvFilter::from_env("AZURE_INIT_LOG"));
@@ -60,10 +75,50 @@ pub fn setup_layers(
         .with_writer(std::io::stderr)
         .with_filter(EnvFilter::from_env("AZURE_INIT_LOG"));
 
+    let log_path = config
+        .map(|cfg| cfg.azure_init_log_path.path.clone())
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_AZURE_INIT_LOG_PATH));
+
+    let file_layer = match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        Ok(file) => {
+            if let Err(e) = file.set_permissions(Permissions::from_mode(0o600))
+            {
+                event!(
+                    Level::WARN,
+                    "Failed to set permissions on {}: {}.",
+                    log_path.display(),
+                    e,
+                );
+            }
+
+            Some(
+                fmt::layer()
+                    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                    .with_writer(file)
+                    .with_filter(EnvFilter::from_env("AZURE_INIT_LOG")),
+            )
+        }
+        Err(e) => {
+            event!(
+                Level::ERROR,
+                "Could not open configured log file {}: {}. Continuing without file logging.",
+                log_path.display(),
+                e
+            );
+
+            None
+        }
+    };
+
     let subscriber = Registry::default()
         .with(stderr_layer)
         .with(otel_layer)
-        .with(emit_kvp_layer);
+        .with(emit_kvp_layer)
+        .with(file_layer);
 
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -59,15 +59,27 @@ pub fn setup_layers(
         .join(","),
     )?;
 
-    let emit_kvp_layer = match EmitKVPLayer::new(
-        std::path::PathBuf::from("/var/lib/hyperv/.kvp_pool_1"),
-        vm_id,
-    ) {
-        Ok(layer) => Some(layer.with_filter(kvp_filter)),
-        Err(e) => {
-            event!(Level::ERROR, "Failed to initialize EmitKVPLayer: {}. Continuing without KVP logging.", e);
-            None
+    let kvp_enabled = config
+        .map(|cfg| cfg.telemetry.kvp_diagnostics)
+        .unwrap_or(true);
+
+    let emit_kvp_layer = if kvp_enabled {
+        match EmitKVPLayer::new(
+            std::path::PathBuf::from("/var/lib/hyperv/.kvp_pool_1"),
+            vm_id,
+        ) {
+            Ok(layer) => Some(layer.with_filter(kvp_filter)),
+            Err(e) => {
+                event!(Level::ERROR, "Failed to initialize EmitKVPLayer: {}. Continuing without KVP logging.", e);
+                None
+            }
         }
+    } else {
+        event!(
+            Level::INFO,
+            "KVP diagnostics are disabled via config. Skipping KVP logging."
+        );
+        None
     };
 
     let stderr_layer = fmt::layer()

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> ExitCode {
     let vm_id: String = get_vm_id()
         .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
 
-    if let Err(e) = setup_layers(tracer, &vm_id) {
+    if let Err(e) = setup_layers(tracer.clone(), &vm_id, None) {
         eprintln!("Warning: Failed to set up tracing layers: {:?}", e);
     }
 
@@ -119,6 +119,10 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+
+    if let Err(e) = setup_layers(tracer, &vm_id, Some(&config)) {
+        tracing::error!("Failed to set final logging subscriber: {e:?}");
+    }
 
     if is_provisioning_complete(Some(&config), &vm_id) {
         tracing::info!(


### PR DESCRIPTION
This PR introduces the ability to enable or disable KVP logging through the `telemetry.kvp_diagnostics` field in the configuration.

### Changes 
- The `setup_layers` function now checks `config.telemetry.kvp_diagnostics` before initializing `emit_kvp_layer`.
- If `kvp_diagnostics = false`, `emit_kvp_layer` is set to `None`, ensuring no logs are written to the EmitKVPStruct.
- If `config` is `None`, the default behavior (`true`) is maintained. 
- Added a unit test in `kvp.rs` to validate that no data is written when KVP is disabled.

### Key Point: Config Tracing & KVP Behavior
- Before the config is loaded, `setup_layers` is called once with `None`, meaning the config values will still be written to KVP. If `kvp_diagnostics = false`, KVP logging will stop after the second call to `setup_layers`, since the new subscriber overrides the previous one.

### Dependency on `probertson-cache-vm-id-logging-new`
This PR is based on `probertson-cache-vm-id-logging-new`, as that branch introduces passing `Config` into `setup_layers`, which is required for this logic.

### Next Steps
- Merge `probertson-cache-vm-id-logging-new` first.
- Then merge this PR to introduce configurable KVP diagnostics.

Resolves #152.
