### PR TITLE
feat(azure-init.service): ensure azure-init wants and starts after kvpd

### DIFF
--- a/config/azure-init.service
+++ b/config/azure-init.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Azure-Init
+After=hypervkvpd.service hv-kvp-daemon.service
+Wants=hypervkvpd.service hv-kvp-daemon.service
 After=network-online.target
 Wants=network-online.target
 ConditionFileIsExecutable=/var/lib/azure-init/azure-init


### PR DESCRIPTION
Ensure kvpd is started before azure-init and want it.

hypervkvpd.service is used by Fedora, RHEL, etc.
hv-kvp-daemon.service is used by Debian, Ubuntu, etc.