### PR TITLE
Update opentelemetry & opentelemetry_sdk to 0.29, and tracing-opentelemetry to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.29"
-opentelemetry_sdk = "0.28"
+opentelemetry_sdk = "0.29"
 tracing-opentelemetry = "0.29"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.29"
 opentelemetry_sdk = "0.29"
-tracing-opentelemetry = "0.29"
+tracing-opentelemetry = "0.30"
 uuid = { version = "1.2", features = ["v4"] }
 chrono = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.33"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.28"
+opentelemetry = "0.29"
 opentelemetry_sdk = "0.28"
 tracing-opentelemetry = "0.29"
 uuid = { version = "1.2", features = ["v4"] }


### PR DESCRIPTION
Update opentelemetry & opentelemetry_sdk to 0.29, tracing-opentelemetry to 0.30.

(Replaces #181 , #182, and #183) 
Combined into one PR to resolve failing CI issue. Testing succeeds with KVP telemetry. 