### PR TITLE
Add `clean` CLI subcommand to remove provisioning marker and allow re-provisioning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,12 +64,9 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Clean up files created by azure-init
+    /// By default, this removes provisioning state data. Optional flags can be used
+    /// to clean logs or additional generated files.
     Clean {
-        /// Cleans the provisioning state for the current VM
-        #[arg(long, default_value_t = true)]
-        provision: bool,
-
         /// Cleans the log files as defined in the configuration file
         #[arg(long)]
         logs: bool,
@@ -210,7 +207,6 @@ async fn main() -> ExitCode {
     let tracer = initialize_tracing();
     let vm_id: String = get_vm_id()
         .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
-
     let opts = Cli::parse();
 
     let temp_layer = tracing_subscriber::fmt::layer()
@@ -245,8 +241,8 @@ async fn main() -> ExitCode {
         config
     );
 
-    if let Some(Command::Clean { provision, logs }) = opts.command {
-        if provision && clean_provisioning_status(&config).is_err() {
+    if let Some(Command::Clean { logs }) = opts.command {
+        if clean_provisioning_status(&config).is_err() {
             return ExitCode::FAILURE;
         }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,10 @@ use std::process::Command;
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 
+use std::fs::{self, File};
+use std::io::Write;
+use tempfile::tempdir;
+
 // Assert help text includes the --groups flag
 #[test]
 fn help_groups() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,6 +16,57 @@ fn help_groups() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .success()
         .stdout(predicate::str::contains("-g, --groups <GROUPS>"));
+
+    Ok(())
+}
+
+#[test]
+fn clean_removes_provision_and_log_files(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    let data_dir = temp_dir.path().join("data");
+    let log_file = temp_dir.path().join("azure-init.log");
+    fs::create_dir_all(&data_dir)?;
+
+    let provisioned_file = data_dir.join("vm-id.provisioned");
+    File::create(&provisioned_file)?;
+
+    let mut log = File::create(&log_file)?;
+    writeln!(log, "fake log line")?;
+
+    let config_contents = format!(
+        r#"
+        [azure_init_data_dir]
+        path = "{}"
+
+        [azure_init_log_path]
+        path = "{}"
+        "#,
+        data_dir.display(),
+        log_file.display()
+    );
+    let config_path = temp_dir.path().join("azure-init-config.toml");
+    fs::write(&config_path, config_contents)?;
+
+    assert!(
+        provisioned_file.exists(),
+        ".provisioned file should exist before cleaning"
+    );
+    assert!(log_file.exists(), "log file should exist before cleaning");
+
+    let mut cmd = Command::cargo_bin("azure-init")?;
+    cmd.args(["--config", config_path.to_str().unwrap(), "clean", "--logs"]);
+
+    cmd.assert().success();
+
+    assert!(
+        !provisioned_file.exists(),
+        "Expected .provisioned file to be deleted"
+    );
+    assert!(
+        !log_file.exists(),
+        "Expected azure-init.log file to be deleted"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR introduces a new azure-init `clean` subcommand to allow users to manually remove the provisioning marker file associated with a VM. This is useful in scenarios where a user wants to re-provision a VM.

## Changes
- Added a clean subcommand to the CLI definition.
- Implemented `clear_provisioning_status()`, which removes the .provisioned file associated with the VM ID.
- Integrated the logic into main.rs, returning `ExitCode::SUCCESS` if cleared or if the .provisioned file isn't found, and `ExitCode::FAILURE` if deletion fails unexpectedly.

## Requesting Feedback
- This functionality has been added into `main.rs` but would it be better to put the `clear_provisioning_status()` into another file or possibly its own file? Was not sure what the best practice here would be. 


Resolves #167 
