### PR TITLE
build(Makefile): add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+BUILD_MODE ?= debug
+BUILD_FLAG := $(if $(filter release,$(BUILD_MODE)),--release,)
+
 build-all:
 	@echo ""
 	@echo "**********************************"
 	@echo "* Building the source code"	
 	@echo "**********************************"
 	@echo ""
-	@cargo build --all
+	@cargo build --all $(BUILD_FLAG)
 
 tests: build-all
 	@echo ""
@@ -32,3 +35,21 @@ clippy:
 	@echo "**********************************"
 	@echo ""
 	@cargo clippy --verbose -- --deny warnings
+
+
+install: build-all
+	@echo ""
+	@echo "**********************************"
+	@echo "* Installing binaries"
+	@echo "**********************************"
+	@echo ""
+	@/bin/install -d $(DESTDIR)/usr/bin
+	@/bin/install -m 0755 target/$(BUILD_MODE)/azure-init $(DESTDIR)/usr/bin/
+
+	@echo ""
+	@echo "**********************************"
+	@echo "* Installing systemd service file"
+	@echo "**********************************"
+	@echo ""
+	@/bin/install -d $(DESTDIR)/usr/lib/systemd/system
+	@/bin/install -m 0644 config/azure-init.service $(DESTDIR)/usr/lib/systemd/system/azure-init.service

--- a/config/azure-init.service
+++ b/config/azure-init.service
@@ -4,11 +4,10 @@ After=hypervkvpd.service hv-kvp-daemon.service
 Wants=hypervkvpd.service hv-kvp-daemon.service
 After=network-online.target
 Wants=network-online.target
-ConditionFileIsExecutable=/var/lib/azure-init/azure-init
 
 [Service]
 Type=oneshot
-ExecStart=/var/lib/azure-init/azure-init
+ExecStart=/usr/bin/azure-init
 StandardOutput=journal+console
 StandardError=journal+console
 

--- a/demo/customdata_template.yml
+++ b/demo/customdata_template.yml
@@ -17,8 +17,7 @@ write_files:
           sleep 1
       done
       wget -O /run/azure-init.tgz __SASURL__
-      tar -xf /run/azure-init.tgz -C /var/lib
-      mv /var/lib/azure-init/azure-init.service /lib/systemd/system/azure-init.service
+      tar -xf /run/azure-init.tgz -C /
       systemctl enable /lib/systemd/system/azure-init.service
       mkdir --parents /etc/netplan
       cat > /etc/netplan/eth0.yaml <<EOF

--- a/demo/image_creation.sh
+++ b/demo/image_creation.sh
@@ -33,21 +33,16 @@ done
 
 EPOCH=$(date +%s)
 TEMP_DIR=/tmp/staging.$EPOCH
-TARGET_DIR=azure-init
-STAGING_DIR=$TEMP_DIR/$TARGET_DIR
+STAGING_DIR=$TEMP_DIR/install
 echo "*********************************************************************"
 echo "Building the agent"
 echo "*********************************************************************"
-
-cargo build
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 echo "*********************************************************************"
 echo "Staging artifacts to $STAGING_DIR"
 echo "*********************************************************************"
-mkdir -p "$STAGING_DIR"
-cp "$ROOT_DIR"/target/debug/azure-init "$STAGING_DIR"/
-cp "$ROOT_DIR"/config/azure-init.service "$STAGING_DIR"/
+make install DESTDIR="$STAGING_DIR"
 cp "$ROOT_DIR"/demo/customdata_template.yml "$TEMP_DIR"/customdata.yml
 echo "Done"
 
@@ -55,7 +50,7 @@ echo "*********************************************************************"
 echo "Creating azure-init.tgz package for upload"
 echo "*********************************************************************"
 rm -f ./azure-init.tgz
-tar cvfz azure-init.tgz -C "$TEMP_DIR" "$TARGET_DIR"
+tar cvfz azure-init.tgz -C "$STAGING_DIR" .
 echo "Done"
 
 RG="${RG:-testagent-$EPOCH}"


### PR DESCRIPTION
Add make install target to install azure-init package to DESTDIR.

Allow for toggling debug vs. release builds with optional BUILD_MODE and a default for debug.

- Install azure-init to /usr/bin/azure-init.
- Install service to /usr/lib/systemd/system/azure-init.service.
- Drop ConditionFileIsExecutable.
- Update demo script.

Example:

`make install DESTDIR=/tmp/foo`