### PR TITLE
Cargo: pin idna_adapter to <=1.2.0 to fix MSRV issues with clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ predicates-core = "1.0.8"
 predicates-tree = "1.0.11"
 tempfile = "3.3.0"
 
+# Pin idna_adapter to <=1.2.0 for MSRV issues with cargo-clippy of Rust 1.78.0.
+idna_adapter = "<=1.2.0"
+
 [dependencies.libazureinit]
 path = "libazureinit"
 version = "0.1.0"


### PR DESCRIPTION
Since `idna_adapter` 1.2.1 started to update crates like `icu*` to 2.0, clippy starts to fail with Rust 1.78.0, the current MSRV of azure-init, like the following:

```
error: rustc 1.78.0 is not supported by the following packages:
  icu_collections@2.0.0 requires rustc 1.82
  icu_normalizer@2.0.0 requires rustc 1.82
  icu_provider@2.0.0 requires rustc 1.82
  idna_adapter@1.2.1 requires rustc 1.82
...
```

Pin `idna_adapter` to `<=1.2.0` to fix the clippy issues.

See also https://github.com/hsivonen/idna_adapter/releases/tag/v1.2.1.

## Testing done

Local run of `cargo clippy` passed with Rust 1.78.0.
