### PR TITLE
.github: ignore automatic updates of idna_adapter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      - dependency-name: "idna_adapter"
+        # stay with <= 1.2.0 for Rust 1.78
       - dependency-name: "litemap"
         # stay with <= 0.7.4 for Rust 1.76
       - dependency-name: "zerofrom"


### PR DESCRIPTION
Ignore automatic updates of `idna_adapter`, to make it compatible with recent changes in https://github.com/Azure/azure-init/pull/198.
