### PR TITLE
Fix clippy warnings

### DIFF
--- a/libazureinit/src/config.rs
+++ b/libazureinit/src/config.rs
@@ -380,7 +380,7 @@ impl Config {
                 tracing::error!("Failed to extract configuration: {:?}", e);
                 Error::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("Configuration error: {:?}", e),
+                    format!("Configuration error: {e:?}"),
                 ))
             })
     }

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -56,7 +56,7 @@ pub(crate) fn run(
             program
         );
         return Err(error::Error::SubprocessFailed {
-            command: format!("{:?}", command),
+            command: format!("{command:?}"),
             status,
         });
     }

--- a/libazureinit/src/provision/user.rs
+++ b/libazureinit/src/provision/user.rs
@@ -181,7 +181,7 @@ fn add_user_for_passwordless_sudo(
         .mode(0o600)
         .open(path)?;
 
-    writeln!(sudoers_file, "{} ALL=(ALL) NOPASSWD: ALL", username)?;
+    writeln!(sudoers_file, "{username} ALL=(ALL) NOPASSWD: ALL")?;
     sudoers_file.flush()?;
     Ok(())
 }

--- a/libazureinit/src/status.rs
+++ b/libazureinit/src/status.rs
@@ -197,7 +197,7 @@ fn private_get_vm_id(
 /// - `false` if provisioning has not been completed (i.e., no provisioning file exists).
 pub fn is_provisioning_complete(config: Option<&Config>, vm_id: &str) -> bool {
     let file_path =
-        get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
+        get_provisioning_dir(config).join(format!("{vm_id}.provisioned"));
 
     if std::path::Path::new(&file_path).exists() {
         tracing::info!("Provisioning already complete. Skipping...");
@@ -225,7 +225,7 @@ pub fn mark_provisioning_complete(
 ) -> Result<(), Error> {
     check_provision_dir(config)?;
     let file_path =
-        get_provisioning_dir(config).join(format!("{}.provisioned", vm_id));
+        get_provisioning_dir(config).join(format!("{vm_id}.provisioned"));
 
     match OpenOptions::new()
         .create(true)

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -572,7 +572,7 @@ mod tests {
 
         let contents =
             std::fs::read(temp_path).expect("Failed to read temp file");
-        println!("Contents of the file (in bytes):\n{:?}", contents);
+        println!("Contents of the file (in bytes):\n{contents:?}");
 
         let slice_size =
             HV_KVP_EXCHANGE_MAX_KEY_SIZE + HV_KVP_EXCHANGE_MAX_VALUE_SIZE;
@@ -593,7 +593,7 @@ mod tests {
             let end = start + slice_size;
             let slice = &contents[start..end];
 
-            println!("Processing slice {}: start={}, end={}", i, start, end);
+            println!("Processing slice {i}: start={start}, end={end}");
             println!("Slice length: {}", slice.len());
 
             let key_section = &slice[..HV_KVP_EXCHANGE_MAX_KEY_SIZE];
@@ -601,11 +601,11 @@ mod tests {
 
             match decode_kvp_item(slice) {
                 Ok((key, value)) => {
-                    println!("Decoded KVP - Key: {}", key);
-                    println!("Decoded KVP - Value: {}\n", value);
+                    println!("Decoded KVP - Key: {key}");
+                    println!("Decoded KVP - Value: {value}\n");
                 }
                 Err(e) => {
-                    panic!("Failed to decode KVP: {}", e);
+                    panic!("Failed to decode KVP: {e}");
                 }
             }
 
@@ -674,21 +674,15 @@ mod tests {
             let (decoded_key, decoded_value) =
                 decode_kvp_item(slice).expect("Failed to decode slice");
 
-            println!("Slice {}: Key: {}", i, decoded_key);
+            println!("Slice {i}: Key: {decoded_key}");
             println!(
-                "Slice {}: Value (length {}): {}",
-                i,
-                decoded_value.len(),
-                decoded_value
+                "Slice {i}: Value (length {decoded_value.len()}): {decoded_value}",
             );
 
-            assert_eq!(decoded_key, key, "Key mismatch in slice {}", i);
+            assert_eq!(decoded_key, key, "Key mismatch in slice {i}");
             assert!(
                 decoded_value.len() <= HV_KVP_AZURE_MAX_VALUE_SIZE,
-                "Value length exceeds limit in slice {}: {} > {}",
-                i,
-                decoded_value.len(),
-                HV_KVP_AZURE_MAX_VALUE_SIZE
+                "Value length exceeds limit in slice {i}: {decoded_value.len()} > {HV_KVP_AZURE_MAX_VALUE_SIZE}"
             );
         }
 

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -676,13 +676,15 @@ mod tests {
 
             println!("Slice {i}: Key: {decoded_key}");
             println!(
-                "Slice {i}: Value (length {decoded_value.len()}): {decoded_value}",
+                "Slice {i}: Value (length {}): {decoded_value}",
+                decoded_value.len()
             );
 
             assert_eq!(decoded_key, key, "Key mismatch in slice {i}");
             assert!(
                 decoded_value.len() <= HV_KVP_AZURE_MAX_VALUE_SIZE,
-                "Value length exceeds limit in slice {i}: {decoded_value.len()} > {HV_KVP_AZURE_MAX_VALUE_SIZE}"
+                "Value length exceeds limit in slice {i}: {} > {HV_KVP_AZURE_MAX_VALUE_SIZE}",
+                decoded_value.len()
             );
         }
 

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -172,10 +172,10 @@ impl EmitKVPLayer {
     ) -> io::Result<()> {
         while let Some(encoded_kvp) = events.recv().await {
             if let Err(e) = file.write_all(&encoded_kvp) {
-                eprintln!("Failed to write to log file: {}", e);
+                eprintln!("Failed to write to log file: {e}");
             }
             if let Err(e) = file.flush() {
-                eprintln!("Failed to flush the log file: {}", e);
+                eprintln!("Failed to flush the log file: {e}");
             }
         }
         Ok(())
@@ -263,7 +263,7 @@ where
                 .format("%Y-%m-%dT%H:%M:%S%.3fZ");
 
             let event_value =
-                format!("Time: {} | Event: {}", event_time_dt, event_message);
+                format!("Time: {event_time_dt} | Event: {event_message}");
 
             self.handle_kvp_operation(
                 event.metadata().level().as_str(),
@@ -324,8 +324,7 @@ where
                     .format("%Y-%m-%dT%H:%M:%S%.3fZ");
 
                 let event_value = format!(
-                    "Start: {} | End: {} | Status: {}",
-                    start_time_dt, end_time_dt, span_status
+                    "Start: {start_time_dt} | End: {end_time_dt} | Status: {span_status}"
                 );
 
                 self.handle_kvp_operation(
@@ -352,8 +351,7 @@ fn generate_event_key(
     span_id: &str,
 ) -> String {
     format!(
-        "{}|{}|{}|{}|{}",
-        EVENT_PREFIX, vm_id, event_level, event_name, span_id
+        "{EVENT_PREFIX}|{vm_id}|{event_level}|{event_name}|{span_id}"
     )
 }
 
@@ -470,7 +468,7 @@ fn truncate_guest_pool_file(kvp_file: &Path) -> Result<(), anyhow::Error> {
             }
         }
         Err(ref e) if e.kind() == ErrorKind::NotFound => {
-            println!("File not found: {:?}", kvp_file);
+            println!("File not found: {kvp_file:?}");
             return Ok(());
         }
         Err(e) => {

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -611,14 +611,12 @@ mod tests {
 
             assert!(
                 key_section.iter().any(|&b| b != 0),
-                "Key section in slice {} should contain non-zero bytes",
-                i
+                "Key section in slice {i} should contain non-zero bytes"
             );
 
             assert!(
                 value_section.iter().any(|&b| b != 0),
-                "Value section in slice {} should contain non-zero bytes",
-                i
+                "Value section in slice {i} should contain non-zero bytes"
             );
         }
     }
@@ -636,8 +634,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "truncate_guest_pool_file returned an error: {:?}",
-            result
+            "truncate_guest_pool_file returned an error: {result:?}",
         );
 
         if let Ok(contents) = std::fs::read_to_string(&temp_path) {
@@ -667,8 +664,7 @@ mod tests {
             assert_eq!(
                 slice.len(),
                 HV_KVP_EXCHANGE_MAX_KEY_SIZE + HV_KVP_EXCHANGE_MAX_VALUE_SIZE,
-                "Slice {} length is incorrect",
-                i
+                "Slice {i} length is incorrect",
             );
 
             let (decoded_key, decoded_value) =
@@ -733,8 +729,7 @@ mod tests {
 
         assert!(
             contents.is_empty(),
-            "KVP file should be empty because kvp_diagnostics is disabled, but found data: {:?}",
-            contents
+            "KVP file should be empty because kvp_diagnostics is disabled, but found data: {contents:?}",
         );
 
         println!("KVP file is empty as expected because kvp_diagnostics is disabled.");

--- a/src/kvp.rs
+++ b/src/kvp.rs
@@ -350,9 +350,7 @@ fn generate_event_key(
     event_name: &str,
     span_id: &str,
 ) -> String {
-    format!(
-        "{EVENT_PREFIX}|{vm_id}|{event_level}|{event_name}|{span_id}"
-    )
+    format!("{EVENT_PREFIX}|{vm_id}|{event_level}|{event_name}|{span_id}")
 }
 
 /// Encodes a key-value pair (KVP) into one or more byte slices. If the value

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ async fn main() -> ExitCode {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("Provisioning failed with error: {:?}", e);
-            eprintln!("{:?}", e);
+            eprintln!("{e:?}");
             let config: u8 = exitcode::CONFIG
                 .try_into()
                 .expect("Error code must be less than 256");
@@ -301,9 +301,9 @@ async fn provision(
 
     let mut default_headers = header::HeaderMap::new();
     let user_agent = if cfg!(debug_assertions) {
-        format!("azure-init v{}-{}", VERSION, COMMIT_HASH)
+        format!("azure-init v{VERSION}-{COMMIT_HASH}")
     } else {
-        format!("azure-init v{}", VERSION)
+        format!("azure-init v{VERSION}")
     };
     let user_agent = header::HeaderValue::from_str(user_agent.as_str())?;
     default_headers.insert(header::USER_AGENT, user_agent);


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
I noticed a previous build of this project was failing the pipeline due to clippy warnings. In downloading the newest cargo and rustup, I replicated this failure. This PR allows the clippy pipeline to pass.

## Testing done
### NOTE
I have not tested this via cloud subscription yet. I do not yet have that set up. I am meeting with Peyton to do so soon.
<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
