### PR TITLE
Split provision and log file test in two

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -20,9 +20,16 @@ fn help_groups() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[test]
-fn clean_removes_only_provision_files_without_log_arg(
-) -> Result<(), Box<dyn std::error::Error>> {
+// Helper function to set up the log and provision files for cleaning
+fn setup_clean_test() -> Result<
+    (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let temp_dir = tempdir()?;
     let data_dir = temp_dir.path().join("data");
     let log_file = temp_dir.path().join("azure-init.log");
@@ -47,6 +54,16 @@ fn clean_removes_only_provision_files_without_log_arg(
     );
     let config_path = temp_dir.path().join("azure-init-config.toml");
     fs::write(&config_path, config_contents)?;
+
+    Ok((temp_dir, data_dir, log_file, config_path))
+}
+
+// Ensures that the `clean` command removes only the provisioned file
+#[test]
+fn clean_removes_only_provision_files_without_log_arg(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, _data_dir, log_file, config_path) = setup_clean_test()?;
+    let provisioned_file = _data_dir.join("vm-id.provisioned");
 
     assert!(
         provisioned_file.exists(),
@@ -68,33 +85,13 @@ fn clean_removes_only_provision_files_without_log_arg(
     Ok(())
 }
 
+// Ensures that the `clean` command with the --logs arg
+// removes both the provisioned file and the log file
 #[test]
 fn clean_removes_provision_and_log_files_with_log_arg(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = tempdir()?;
-    let data_dir = temp_dir.path().join("data");
-    let log_file = temp_dir.path().join("azure-init.log");
-    fs::create_dir_all(&data_dir)?;
-
-    let provisioned_file = data_dir.join("vm-id.provisioned");
-    File::create(&provisioned_file)?;
-
-    let mut log = File::create(&log_file)?;
-    writeln!(log, "fake log line")?;
-
-    let config_contents = format!(
-        r#"
-        [azure_init_data_dir]
-        path = "{}"
-
-        [azure_init_log_path]
-        path = "{}"
-        "#,
-        data_dir.display(),
-        log_file.display()
-    );
-    let config_path = temp_dir.path().join("azure-init-config.toml");
-    fs::write(&config_path, config_contents)?;
+    let (_temp_dir, _data_dir, log_file, config_path) = setup_clean_test()?;
+    let provisioned_file = _data_dir.join("vm-id.provisioned");
 
     assert!(
         provisioned_file.exists(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -36,7 +36,7 @@ fn setup_clean_test() -> Result<
     fs::create_dir_all(&data_dir)?;
 
     let provisioned_file = data_dir.join("vm-id.provisioned");
-    File::create(&provisioned_file)?;
+    File::create(provisioned_file)?;
 
     let mut log = File::create(&log_file)?;
     writeln!(log, "fake log line")?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,7 +23,15 @@ fn help_groups() -> Result<(), Box<dyn std::error::Error>> {
 // Helper function to create a test log and provision file from multiple tests
 fn create_test_log_and_provision_files(
     temp_dir: &tempfile::TempDir,
-) -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf, std::path::PathBuf), Box<dyn std::error::Error>> {
+) -> Result<
+    (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let data_dir = temp_dir.path().join("data");
     let log_file = temp_dir.path().join("azure-init.log");
     fs::create_dir_all(&data_dir)?;
@@ -52,23 +60,24 @@ fn create_test_log_and_provision_files(
 }
 
 #[test]
-fn provision_and_log_files_are_created() -> Result<(), Box<dyn std::error::Error>> {
+fn provision_and_log_files_are_created(
+) -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempdir()?;
-    let (_data_dir, log_file, provisioned_file, _config_path) = create_test_log_and_provision_files(&temp_dir)?;
+    let (_data_dir, log_file, provisioned_file, _config_path) =
+        create_test_log_and_provision_files(&temp_dir)?;
 
-    assert!(
-        provisioned_file.exists(),
-        ".provisioned file should exist"
-    );
+    assert!(provisioned_file.exists(), ".provisioned file should exist");
     assert!(log_file.exists(), "log file should exist");
 
     Ok(())
 }
 
 #[test]
-fn clean_removes_provision_and_log_files() -> Result<(), Box<dyn std::error::Error>> {
+fn clean_removes_provision_and_log_files(
+) -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempdir()?;
-    let (_data_dir, log_file, provisioned_file, config_path) = create_test_log_and_provision_files(&temp_dir)?;
+    let (_data_dir, log_file, provisioned_file, config_path) =
+        create_test_log_and_provision_files(&temp_dir)?;
 
     let mut cmd = Command::cargo_bin("azure-init")?;
     cmd.args(["--config", config_path.to_str().unwrap(), "clean", "--logs"]);


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
This PR fixes issue #206 and splits `clean_removes_provision_and_log_files` into two tests. The first test, `provision_and_log_files_are_created` first ensures that the provisioning and log files can be created, and then `clean_removes_provision_and_log_files` actually deletes these files after they have been created. 

## How to use
This can be used by running unit tests in the workspace with the below commands.
<!-- [ Describe what reviewers need to do in order to validate this PR ] -->

## Testing done
As this is just a unit testing change, I have not done any image tests. I have run: 
```
cargo test --all-features --workspace
cargo fmt --all --check
```

<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
