### PR TITLE
Lock Account instead of Deleting Passwords

### DIFF
--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -50,7 +50,7 @@ fn passwd(user: &User) -> Result<(), Error> {
 
     if user.password.is_none() {
         let mut command = Command::new(path_passwd);
-        command.arg("-d").arg(&user.name);
+        command.arg("-l").arg(&user.name);
         crate::run(command)?;
     } else {
         // creating user with a non-empty password is not allowed.


### PR DESCRIPTION
Switch the `passwd` invocation in `password.rs` from `-d` (delete) to `-l ` (lock), so that when no password is provided, the user’s account is disabled rather than left with an empty password. 