### PR TITLE
Clarify fallback log message when OVF environment is unavailable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn get_environment() -> Result<Environment, anyhow::Error> {
     }
 
     environment.ok_or_else(|| {
-        tracing::error!("Unable to get list of block devices");
+        tracing::warn!("Failed to find valid OVF provisioning data on any block device. Falling back to IMDS.");
         anyhow::anyhow!("Unable to get list of block devices")
     })
 }


### PR DESCRIPTION
This PR updates a misleading error log in get_environment() that previously stated: "Unable to get list of block devices."