### PR TITLE
Move kvp.rs into libazureinit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 opentelemetry = "0.30"
 opentelemetry_sdk = "0.30"
 tracing-opentelemetry = "0.31"
-uuid = { version = "1.2", features = ["v4"] }
-chrono = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -32,7 +32,11 @@ zerofrom = "=0.1.5"
 # The major difference in 0.7.5 is the switch to core::error; there's also a few API additions.
 # This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
 litemap = "=0.7.4"
-uuid = "1.3"
+uuid = { version = "1.3", features = ["v4"] }
+anyhow = "1.0.81"
+sysinfo = "0.36"
+chrono = "0.4"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/libazureinit/src/kvp.rs
+++ b/libazureinit/src/kvp.rs
@@ -493,7 +493,7 @@ fn get_uptime() -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libazureinit::config::{Config, Telemetry};
+    use crate::config::{Config, Telemetry};
     use tempfile::NamedTempFile;
     use tokio::time::{sleep, Duration};
     use tracing::instrument;

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -6,7 +6,9 @@ pub mod error;
 pub mod goalstate;
 pub(crate) mod http;
 pub mod imds;
+mod kvp;
 pub mod media;
+pub use kvp::EmitKVPLayer;
 
 mod provision;
 pub use provision::{user::User, Provision};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,8 +12,8 @@ use tracing_subscriber::{
     fmt, layer::SubscriberExt, EnvFilter, Layer, Registry,
 };
 
-use crate::kvp::EmitKVPLayer;
 use libazureinit::config::Config;
+use libazureinit::EmitKVPLayer;
 
 pub fn initialize_tracing() -> sdktrace::Tracer {
     let provider = SdkTracerProvider::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 use std::path::PathBuf;
-mod kvp;
 mod logging;
 pub use logging::{initialize_tracing, setup_layers};
 


### PR DESCRIPTION
## Summary

This commit refactors the codebase by relocating `kvp.rs` from the main crate into the `libazureinit` crate. This change is an architectural step toward consolidating KVP event formatting and emission within the core provisioning library, and making the `send_event` functionality directly available throughout the library.

## Next Steps

Once the new health reporting endpoint PR is merged (#188 ) , `we can send events to kvp directly within `report_failure` or `report_success.`
---
