### PR TITLE
Prevent Double Thread Panic and Fix Mutable SpanStatus in KVP Layer

### DIFF
--- a/libazureinit/src/goalstate.rs
+++ b/libazureinit/src/goalstate.rs
@@ -134,6 +134,10 @@ pub async fn get_goalstate(
                     error.into()
                 });
                 if goalstate.is_ok() {
+                    tracing::info!(
+                        operation_status = "success",
+                        "Successfully retrieved and parsed goalstate."
+                    );
                     return goalstate;
                 }
             }

--- a/libazureinit/src/http.rs
+++ b/libazureinit/src/http.rs
@@ -126,7 +126,12 @@ async fn request(
                         match response.error_for_status() {
                             Ok(response) => {
                                 if statuscode == StatusCode::OK {
-                                    tracing::info!(target: "libazureinit::http::success", "HTTP response succeeded with status {}", statuscode);
+                                    tracing::info!(
+                                        target: "libazureinit::http::success",
+                                        operation_status = "success",
+                                        "HTTP response succeeded with status {}",
+                                        statuscode
+                                    );
                                     return Ok((response, retry_for.saturating_sub(now.elapsed() + retry_interval)));
                                 }
                             },
@@ -144,7 +149,7 @@ async fn request(
                     },
                     Err(error) => {
                         let _enter = span.enter();
-                        tracing::error!(?error, "HTTP request failed to complete");
+                        tracing::warn!(?error, "HTTP request failed to complete");
                     },
                 }
             span.in_scope(||{

--- a/libazureinit/src/imds.rs
+++ b/libazureinit/src/imds.rs
@@ -203,6 +203,10 @@ pub async fn query(
                         error.into()
                     });
                 if metadata.is_ok() {
+                    tracing::info!(
+                        operation_status = "success",
+                        "Successfully retrieved and parsed IMDS metadata."
+                    );
                     return metadata;
                 }
             }

--- a/libazureinit/src/provision/ssh.rs
+++ b/libazureinit/src/provision/ssh.rs
@@ -99,6 +99,10 @@ pub(crate) fn provision_ssh(
 
     chown(&authorized_keys_path, Some(user.uid), Some(user.gid))?;
 
+    tracing::info!(
+        operation_status = "success",
+        "Successfully provisioned SSH keys."
+    );
     Ok(())
 }
 
@@ -151,7 +155,7 @@ fn run_sshd_command(
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            error!(
+            tracing::warn!(
                 code=output.status.code().unwrap_or(-1),
                 stdout=%stdout,
                 stderr=%stderr,
@@ -160,7 +164,7 @@ fn run_sshd_command(
             None
         }
         Err(e) => {
-            error!(
+            tracing::warn!(
                 error=%e,
                 "Failed to execute sshd -G, assuming sshd configuration defaults",
             );


### PR DESCRIPTION
This is the second PR to addresses a bug that was causing the azure-init agent to panic during provisioning due to a race condition in the Hyper-V KVP tracing layer.

## Issue
The root cause was a "Time-of-check to time-of-use" (TOCTOU) race condition in the `set_span_as_failed` function. When multiple ERROR events were fired in quick succession within the same span, the following would occur:
1. Thread A would check if a SpanStatus::Failure extension existed. It didn't.
2. Before Thread A could insert the extension, the OS would switch context to Thread B.
3. Thread B would also check for the extension, find nothing, and proceed to insert it successfully.
4. When control returned to Thread A, it would also attempt to insert the extension, which is not allowed by the tracing library, causing an immediate panic.
5. This initial panic would occur while holding a lock within the tracing-subscriber's registry, "poisoning" it and leading to the secondary Mutex poisoned panic when the span was closed.

## Why Just Checking Before Insert Wasn't Enough

An earlier attempt (#218 ) was made to fix this by adding the if extensions.get_mut::<SpanStatus>().is_none() check.  This fix ended up being insufficient because the check and the subsequent action were not an atomic operation.  The original unit test also passed because it fired the two error events sequentially from the same task, rather than two concurrent threads. 

## Changes in This PR
1. Introduced std::sync::Mutex: The critical section in set_span_as_failed is now protected by a Mutex. This serializes access, ensuring that only one thread at a time can check for and insert the SpanStatus, making the operation atomic. Also, if something were to happen and the mutex were to be poisoned, we recover by logging a message and continuing so that a mutex poisoning doesn't break the provisioning process.
2. Enhanced `SpanStatus` Logic: The `SpanStatus` is now an enum that can represent both Success and Failure. This allows for more expressive and accurate tracking of an operation's lifecycle. ERROR level events will mark a span as Failure.
3. Final Status Override for Transient Errors: To support scenarios with transient errors (e.g., network retries), the tracing layer can now override a Failure status with Success. If an event contains a special field (`operation_status = "success"`), it will mark the span as succeeded, regardless of any prior ERROR events. This ensures the final reported status of the span accurately reflects the ultimate outcome of the operation.
4. Updated Unit Test: 
 - The `test_multiple_error_events_in_span_does_not_panic` test has been updated to use `tokio::spawn` and `tokio::sync::Barrier` to fire two error events from concurrent tasks, synchronizing them to occur at almost the exact same time. This better reproduces the conditions of the race condition. 
 -  A new test, `test_span_status_override`, has been added to verify that a final success event correctly overrides a previous failure status, confirming the new transient error handling logic works as expected.

## Resources:
- https://en.m.wikipedia.org/wiki/Time-of-check_to_time-of-use
- https://doc.rust-lang.org/book/ch16-03-shared-state.html
