### PR TITLE
Remove SpanStatus to to Fix Concurrency Issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,6 @@ async fn main() -> ExitCode {
     match provision(config, &vm_id, opts).await {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
-            tracing::error!("Provisioning failed with error: {:?}", e);
             eprintln!("{e:?}");
             let config: u8 = exitcode::CONFIG
                 .try_into()
@@ -279,7 +278,7 @@ async fn main() -> ExitCode {
     }
 }
 
-#[instrument(name = "root", skip_all)]
+#[instrument(name = "root", skip_all, ret(level = "info"), err)]
 async fn provision(
     config: Config,
     vm_id: &str,


### PR DESCRIPTION
## Reasoning: 
Previously, the success or failure of an operation was tracked using a `SpanStatus` enum that was inserted into a span's extensions. When multiple `ERROR` events occurred in the same span from concurrent tasks, it created a TOCTOU race condition: 
1. Two threads would simultaneously check if a `SpanStatus::Failure` existed. 
2. Both would see that it didn't and then attempt to insert it. 
3. The second insertion attempt would cause a panic, and because this happened in a locked tracing structure, it would poison the mutex and lead to a provisioning failure. 

## Solution
This PR removes the `SpanStatus` and all associated `mutex` based logic entirely. Instead of manually tracking the span state, the tracing setup now leverages built-in functionality: 
- The primary `provision()` function is now instrumented with `#[instrument(ret(level = "info), err)]` macro, which automatically and atomically logs an event upon the function's completion. This is the primary `root` span that encompasses all other spans. 
 - An `INFO` event is logged if the function returns `Ok`. 
 - An `ERROR` event, including the error details, is logged if the function returns `Err`.

This removes the underlying cause of the race condition without sacrificing the purpose of SpanStatus. 
