### PR TITLE
Refactor library: move logging.rs and kvp.rs into libazureinit crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
 sysinfo = "0.36"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.30"
-opentelemetry_sdk = "0.30"
-tracing-opentelemetry = "0.31"
-uuid = { version = "1.2", features = ["v4"] }
-chrono = "0.4"
 tokio-util = "0.7" 
 
 [dev-dependencies]

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.11"
 whoami = "1"
 anyhow = "1.0.81"
+gag = "1.0.0"
 
 [lib]
 name = "libazureinit"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -19,6 +19,13 @@ serde_json = "1.0.96"
 nix = {version = "0.30.1", features = ["fs", "user"]}
 block-utils = "0.11.1"
 tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+opentelemetry = "0.30"
+opentelemetry_sdk = "0.30"
+tracing-opentelemetry = "0.31"
+tokio-util = "0.7"
+sysinfo = "0.36"
+anyhow = "1"
 fstab = "0.4.0"
 toml = "0.9"
 regex = "1"
@@ -32,7 +39,7 @@ zerofrom = "=0.1.5"
 # The major difference in 0.7.5 is the switch to core::error; there's also a few API additions.
 # This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
 litemap = "=0.7.4"
-uuid = "1.3"
+uuid = { version = "1.3", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1"
 

--- a/libazureinit/src/health.rs
+++ b/libazureinit/src/health.rs
@@ -136,6 +136,10 @@ async fn _report(
     description: Option<String>,
     config: &Config,
 ) -> Result<(), Error> {
+    if let Some(description_str) = &description {
+        tracing::info!(health_report = %description_str);
+    }
+
     let body = if let Some(sub) = substatus {
         json!({
             "state": state.to_string(),

--- a/libazureinit/src/health.rs
+++ b/libazureinit/src/health.rs
@@ -137,7 +137,10 @@ async fn _report(
     config: &Config,
 ) -> Result<(), Error> {
     if let Some(description_str) = &description {
-        tracing::info!(health_report = %description_str);
+        tracing::info!(
+            target: "libazureinit::health::report",
+            health_report = %description_str
+        );
     }
 
     let body = if let Some(sub) = substatus {

--- a/libazureinit/src/kvp.rs
+++ b/libazureinit/src/kvp.rs
@@ -190,7 +190,10 @@ impl Visit for StringVisitor<'_> {
         field: &tracing::field::Field,
         value: &dyn std_fmt::Debug,
     ) {
-        write!(self.string, "{}={:?}; ", field.name(), value)
+        if !self.string.is_empty() {
+            self.string.push_str(", ");
+        }
+        write!(self.string, "{}={:?}", field.name(), value)
             .expect("Writing to a string should never fail");
     }
 }

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -6,6 +6,8 @@ pub mod error;
 pub mod health;
 pub(crate) mod http;
 pub mod imds;
+mod kvp;
+pub mod logging;
 pub mod media;
 
 mod provision;

--- a/libazureinit/src/logging.rs
+++ b/libazureinit/src/logging.rs
@@ -78,7 +78,7 @@ pub struct Kvp<S: Subscriber> {
     /// The `JoinHandle` for the background task responsible for writing
     /// KVP data to the file. The caller can use this handle to wait for
     /// the writer to finish.
-    pub writer: JoinHandle<std::io::Result<()>>,
+    writer: JoinHandle<std::io::Result<()>>,
     shutdown: CancellationToken,
 }
 

--- a/libazureinit/src/logging.rs
+++ b/libazureinit/src/logging.rs
@@ -14,8 +14,8 @@ use tracing_subscriber::{
     fmt, layer::SubscriberExt, EnvFilter, Layer, Registry,
 };
 
+use crate::config::Config;
 use crate::kvp::Kvp;
-use libazureinit::config::Config;
 
 pub type LoggingSetup = (
     Box<dyn Subscriber + Send + Sync + 'static>,

--- a/libazureinit/src/logging.rs
+++ b/libazureinit/src/logging.rs
@@ -65,6 +65,7 @@ pub fn setup_layers(
             "libazureinit::status::success",
             "libazureinit::status::retrieved_vm_id",
             "libazureinit::health::status",
+            "libazureinit::health::report",
         ]
         .join(","),
     )?;
@@ -227,9 +228,13 @@ mod tests {
         // Redirect stderr to a buffer
         let mut buf = BufferRedirect::stderr().unwrap();
 
-        let (subscriber, _kvp_handle) =
-            setup_layers(tracer, test_vm_id, &config, graceful_shutdown.clone())
-                .expect("Failed to setup layers");
+        let (subscriber, _kvp_handle) = setup_layers(
+            tracer,
+            test_vm_id,
+            &config,
+            graceful_shutdown.clone(),
+        )
+        .expect("Failed to setup layers");
 
         tracing::subscriber::with_default(subscriber, || {
             tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,11 +258,6 @@ async fn main() -> ExitCode {
                 );
             }
 
-            tracing::error!(
-                health_report = "failure",
-                reason = %error,
-                "Invalid config during early startup"
-            );
             return ExitCode::FAILURE;
         }
     };
@@ -300,11 +295,7 @@ async fn main() -> ExitCode {
                     );
                 }
 
-                tracing::info!(
-                    target: "azure_init",
-                    health_report = "success",
-                    "Provisioning completed successfully"
-                );
+                tracing::info!("Provisioning completed successfully");
 
                 ExitCode::SUCCESS
             }
@@ -330,11 +321,7 @@ async fn main() -> ExitCode {
                     );
                 }
 
-                tracing::error!(
-                    health_report = "failure",
-                    reason = %e,
-                    "Provisioning failed with error"
-                );
+                tracing::error!("Provisioning failed with error: {e:?}");
 
                 let config: u8 = exitcode::CONFIG
                     .try_into()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 use std::path::PathBuf;
-mod kvp;
-mod logging;
-pub use logging::{initialize_tracing, setup_layers};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
@@ -13,7 +10,9 @@ use libazureinit::{
     get_vm_id,
     health::{report_failure, report_ready},
     imds::{query, InstanceMetadata},
-    is_provisioning_complete, mark_provisioning_complete,
+    is_provisioning_complete,
+    logging::{initialize_tracing, setup_layers},
+    mark_provisioning_complete,
     media::{get_mount_device, mount_parse_ovf_env, Environment},
     reqwest::{header, Client},
     Provision, User,


### PR DESCRIPTION
This commit refactors the codebase by relocating `kvp.rs` and `logging.rs` from the main crate into the libazureinit crate. This change is an architectural step toward consolidating KVP event formatting and emission within the core provisioning library and for streamlining the report_ready logic. 

This is also required for Afterburn integration. 

# Changes:
- The `kvp.rs` and `logging.rs` modules were moved from the main azure-init binary crate into the libazureinit library.
- The logic for generating health report strings was centralized in `health.rs`. The KVP logging mechanism was also simplified, removing redundant logic that was previously spread between `kvp.rs` and `health.rs`. Now, `health.rs` is now the single source of truth for what a health report contains, and it emits the properly formatted health report directly to `kvp.rs` as a value. 
- A few other minor changes were made to ensure `azure-init.log` contains what is expected. During the refactor, logs previously sent to `azure-init.log` were suppressed. Minor fixes to the filtering setup were made to address this and unit tests were added to prevent future regression.  