### PR TITLE
Adding password functionality to `libazureinit`

### DIFF
--- a/doc/azure_init_behavior.md
+++ b/doc/azure_init_behavior.md
@@ -12,8 +12,8 @@ This document describes the behavior of the reference `azure-init` binary with r
 
 `libazureinit` provides decoupled password management building blocks:
 
-- **`set_user_password(user, password)`** - Sets a password for the specified user via `chpasswd`, with no side effects
-- **`lock_user(user)`** - Locks the specified user account via `passwd -l`, with no side effects
+- **`set_user_password(username, password)`** - Sets a password for the specified user via `chpasswd`, with no side effects
+- **`lock_user(username)`** - Locks the specified user account via `passwd -l`, with no side effects
 
 These functions are exported in the public API and can be used independently by external consumers for fine-grained password management without coupling to other behaviors.
 

--- a/doc/azure_init_behavior.md
+++ b/doc/azure_init_behavior.md
@@ -1,0 +1,121 @@
+# azure-init behavior overview
+
+This document describes the behavior of the reference `azure-init` binary with respect to user creation, password handling, and SSH configuration. Library consumers can customize behavior via `libazureinit` APIs and configuration.
+
+## Summary
+
+- By default, the reference `azure-init` binary does not set a password. It always creates the user and then locks the account with `passwd -l` because it never opts in to password provisioning.
+- Library consumers may opt in to password provisioning by calling `User::with_password(...)`, which sets the password using `chpasswd` via stdin.
+- `sshd_config` `PasswordAuthentication` is set according to IMDS `disablePasswordAuthentication` only when the real password backend is active (default backend is `passwd`).
+
+## User and password behavior
+
+- The password provisioner has two modes:
+  - **Password provided (`User.password = Some`)**: Set the password securely with `chpasswd` by piping "username:password" to stdin. Nothing sensitive is placed on argv or logs.
+  - **Password absent (`User.password = None`)**: Lock the account with `passwd -l`.
+
+- The reference `azure-init` binary never calls `User::with_password`, so the constructed `User` has `password = None`. As a result, the password provisioner always takes the lock path (`passwd -l`). There is no alternate mechanism elsewhere that performs the lock.
+
+- Build-time path to `passwd` is provided via the `PATH_PASSWD` environment variable (see `libazureinit/build.rs`).
+
+### Relevant API usage in the binary
+
+- `azure-init` builds a `User` without a password and passes it into provisioning alongside IMDS' `disablePasswordAuthentication` flag:
+
+```356:448:src/main.rs
+async fn provision(
+    config: Config,
+    vm_id: &str,
+    opts: Cli,
+) -> Result<(), anyhow::Error> {
+    // ...
+    let im = instance_metadata
+        .clone()
+        .ok_or::<LibError>(LibError::InstanceMetadataFailure)?;
+
+    let user =
+        User::new(username, im.compute.public_keys).with_groups(opts.groups);
+
+    Provision::new(
+        im.compute.os_profile.computer_name,
+        user,
+        config,
+        im.compute.os_profile.disable_password_authentication,
+    )
+    .provision()?;
+    // ...
+}
+```
+
+### How passwords/locking are applied
+
+- The password provisioner executes one of the following based on `User.password`:
+
+```49:96:libazureinit/src/provision/password.rs
+#[instrument(skip_all)]
+fn passwd(user: &User) -> Result<(), Error> {
+    if let Some(ref password) = user.password {
+        // Set password via chpasswd (stdin)
+        // ...
+    } else {
+        // No password provided; lock the account
+        let path_passwd = env!("PATH_PASSWD");
+        let mut command = Command::new(path_passwd);
+        command.arg("-l").arg(&user.name);
+        crate::run(command)?;
+    }
+    Ok(())
+}
+```
+
+## SSH PasswordAuthentication
+
+- When the real password backend is active (i.e., `password_provisioners.backends` includes `passwd`), `azure-init` writes an `sshd_config` drop-in that reflects IMDS `disablePasswordAuthentication`:
+  - If IMDS `disablePasswordAuthentication` is `true`: write `PasswordAuthentication no`.
+  - If `false`: write `PasswordAuthentication yes`.
+- If a fake backend is configured (e.g., during tests), `sshd_config` is not modified.
+
+```78:113:libazureinit/src/provision/mod.rs
+self.config
+    .password_provisioners
+    .backends
+    .iter()
+    .find_map(|backend| match backend {
+        PasswordProvisioner::Passwd => {
+            PasswordProvisioner::Passwd.set(&self.user).ok()
+        }
+        #[cfg(test)]
+        PasswordProvisioner::FakePasswd => Some(()),
+    })
+    .ok_or(Error::NoPasswordProvisioner)?;
+
+let ssh_config_update_required = self
+    .config
+    .password_provisioners
+    .backends
+    .first()
+    .is_some_and(|b| matches!(b, PasswordProvisioner::Passwd));
+
+if ssh_config_update_required {
+    let sshd_config_path = ssh::get_sshd_config_path();
+    ssh::update_sshd_config(
+        sshd_config_path,
+        self.disable_password_authentication,
+    )?;
+}
+```
+
+## FAQ
+
+- **Q: "only creates locked accounts." On what condition?**
+  - **A:** When `User.password` is not specified. In the reference binary, `User::with_password` is never called, so `User.password` is always `None` and the account is consistently locked via `passwd -l`.
+
+- **Q: Is it simply not specifying `user.password` and always incurring `-l`?**
+  - **A:** Yes. Locking is performed by the same password provisioner that would set a password; it detects the absence of a password and runs `passwd -l`.
+
+- **Q: Is the account locked by some other mechanism if the password path isn’t called?**
+  - **A:** No. There is no alternate locking path; it is handled in the password provisioner itself.
+
+## Security notes
+
+- Passwords (when opted-in by library consumers) are set using `chpasswd` via stdin to avoid exposing secrets in process arguments or logs. 

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -36,6 +36,7 @@ figment = { version = "0.10", features = ["toml"] }
 uuid = { version = "1.3", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1"
+zeroize = "1.8"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/libazureinit/src/lib.rs
+++ b/libazureinit/src/lib.rs
@@ -11,7 +11,11 @@ pub mod logging;
 pub mod media;
 
 mod provision;
-pub use provision::{user::User, Provision};
+pub use provision::{
+    password::{lock_user, set_user_password},
+    user::User,
+    Provision,
+};
 mod status;
 pub use status::{
     get_vm_id, is_provisioning_complete, mark_provisioning_complete,

--- a/libazureinit/src/logging.rs
+++ b/libazureinit/src/logging.rs
@@ -47,6 +47,7 @@ fn default_kvp_filter() -> Result<EnvFilter, anyhow::Error> {
             "libazureinit::status::retrieved_vm_id",
             "libazureinit::health::status",
             "libazureinit::health::report",
+            "libazureinit::password::status",
         ]
         .join(","),
     )?)

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -54,8 +54,11 @@ impl PasswordProvisioner {
 /// - If no password is provided, it disables password-based login by locking the
 ///   account's password using `passwd -l`.
 ///
-/// Note: While `libazureinit` supports password provisioning, the reference
-/// `azure-init` binary does not use this feature and only creates locked accounts.
+/// Reference `azure-init` behavior: it never calls `User::with_password`.
+/// Therefore `user.password` is `None`, and this function always locks the
+/// account via `passwd -l` (there is no alternate locking path). Library
+/// consumers that want a password must explicitly call `User::with_password`.
+/// See `doc/azure_init_behavior.md` for details.
 #[instrument(skip_all)]
 fn passwd(user: &User) -> Result<(), Error> {
     if let Some(ref password) = user.password {

--- a/libazureinit/src/provision/password.rs
+++ b/libazureinit/src/provision/password.rs
@@ -49,12 +49,12 @@ impl PasswordProvisioner {
 /// Manages the user's password during provisioning.
 ///
 /// This function supports two modes of operation:
-/// - If a password is provided in the `User` object, it sets the password securely 
+/// - If a password is provided in the `User` object, it sets the password securely
 ///   using the `chpasswd` utility via stdin to avoid exposing secrets.
-/// - If no password is provided, it disables password-based login by locking the 
+/// - If no password is provided, it disables password-based login by locking the
 ///   account's password using `passwd -l`.
 ///
-/// Note: While `libazureinit` supports password provisioning, the reference 
+/// Note: While `libazureinit` supports password provisioning, the reference
 /// `azure-init` binary does not use this feature and only creates locked accounts.
 #[instrument(skip_all)]
 fn passwd(user: &User) -> Result<(), Error> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -20,6 +20,18 @@ fn help_groups() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// Ensure no password-related flags are exposed by the CLI
+#[test]
+fn help_has_no_password_flags() -> Result<(), Box<dyn std::error::Error>> {
+    let mut command = Command::cargo_bin("azure-init")?;
+    command.arg("--help");
+    command
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("(?i)password").unwrap().not());
+    Ok(())
+}
+
 // Helper function to set up the log and provision files for cleaning
 fn setup_clean_test() -> Result<
     (

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -29,7 +29,10 @@ fn help_has_no_password_flags() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .success()
         .stdout(predicate::str::is_match("(?i)password").unwrap().not());
-  
+
+    Ok(())
+}
+
 // Assert that the --version flag works and outputs the version
 #[test]
 fn version_flag() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Goal
- Adding password functionality to `libazureinit` as part of the ongoing work with Flatcar/Afterburn. 

## Changes
- Implement password setting in `PasswordProvisioner` using `chpasswd` with piped stdin (no secrets in argv/logs)
- Preserve account locking when no password via passwd -l using `PATH_PASSWD` (which was part of existing functionality). 
- Add rustdoc to `password.rs` documenting behavior and usage example
- No change to `azure-init` binary behavior: it does not set passwords; external consumers can opt-in via `User::with_password(...)`

## Update unit tests:
- `password.rs`: mock-based tests for set and lock flows (no external commands)
- `mod.rs:` assert sshd update gating unchanged (true with `Passwd`, false with `FakePasswd`)
- `tests/cli.rs`: ensure CLI exposes no password-related flags


Resolves #52 
