### PR TITLE
Cargo: pin sysinfo to 0.36

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,7 @@ updates:
         # stay with <= 1.2.0 for Rust 1.78
       - dependency-name: "litemap"
         # stay with <= 0.7.4 for Rust 1.76
+      - dependency-name: "sysinfo"
+        # stay with <= 0.36 for Rust < 1.85
       - dependency-name: "zerofrom"
         # stay with <= 0.1.5 for Rust 1.76

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,5 @@ updates:
     ignore:
       - dependency-name: "idna_adapter"
         # stay with <= 1.2.0 for Rust 1.78
-      - dependency-name: "litemap"
-        # stay with <= 0.7.4 for Rust 1.76
       - dependency-name: "sysinfo"
         # stay with <= 0.36 for Rust < 1.85
-      - dependency-name: "zerofrom"
-        # stay with <= 0.1.5 for Rust 1.76

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ anyhow = "1.0.81"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 clap = { version = "4.5.21", features = ["derive", "cargo", "env"] }
-sysinfo = "0.36"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tokio-util = "0.7" 
+
+# Pin sysinfo to <=0.36 for MSRV issues with Rust < 1.85.0.
+# This should be unpinned around 2026-02-17 if we continue with our ~1 year MSRV policy
+sysinfo = "=0.36"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -33,14 +33,6 @@ toml = "0.9"
 regex = "1"
 lazy_static = "1.4"
 figment = { version = "0.10", features = ["toml"] }
-# Pinned to 0.1.5 since 0.1.6 bumps its MSRV to 1.81.
-# The major difference in 0.1.6 is the switch to core::error
-# This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
-zerofrom = "=0.1.5"
-# Pinned to 0.7.4 since 0.7.5 bumps its MSRV to 1.81.
-# The major difference in 0.7.5 is the switch to core::error; there's also a few API additions.
-# This should be unpinned on or around 2025-09-05 if we continue with our ~1 year MSRV policy
-litemap = "=0.7.4"
 uuid = { version = "1.3", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1"

--- a/libazureinit/Cargo.toml
+++ b/libazureinit/Cargo.toml
@@ -24,7 +24,9 @@ opentelemetry = "0.30"
 opentelemetry_sdk = "0.30"
 tracing-opentelemetry = "0.31"
 tokio-util = "0.7"
-sysinfo = "0.36"
+# Pin sysinfo to <=0.36 for MSRV issues with Rust < 1.85.0.
+# This should be unpinned around 2026-02-17 if we continue with our ~1 year MSRV policy
+sysinfo = "=0.36"
 anyhow = "1"
 fstab = "0.4.0"
 toml = "0.9"


### PR DESCRIPTION
Pin `sysinfo` to `=0.36` for MSRV issues with Rust < 1.85.0. This should be unpinned around 2026-02-17 if we continue with our ~1 year MSRV policy.

Without the pinning, CI with Rust 1.81 fails like:

```
Downloaded sysinfo v0.37.0
error: failed to parse manifest at `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sysinfo-0.37.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0 (eeb90cda1 2024-09-04)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/night
```

Also do not pin `litemap`, `zerofrom` any more, as the current MSRV for the last 1 year becomes 1.81.0, which does not require to pin specific versions of litemap or zerofrom.

Fixes https://github.com/Azure/azure-init/issues/174