### PR TITLE
Emit a pre-HTTP KVP event to mark start of `_report`

### DIFF
--- a/libazureinit/src/health.rs
+++ b/libazureinit/src/health.rs
@@ -136,6 +136,13 @@ async fn _report(
     description: Option<String>,
     config: &Config,
 ) -> Result<(), Error> {
+    tracing::info!(
+        target: "libazureinit::health::status",
+        "Beginning report to wireserver: state={}, substatus={:?}",
+        state,
+        substatus
+    );
+
     if let Some(description_str) = &description {
         tracing::info!(
             target: "libazureinit::health::report",


### PR DESCRIPTION
This PR adds a quick `tracing::info!` event before the HTTP connection in `_report` to mark a "start" signal that is captured in `.kvp_pool_1` before we connect to Wireserver and report ready. 