### PR TITLE
Fix: Guarantee health::status KVP emission via function-level span

### DIFF
--- a/libazureinit/src/health.rs
+++ b/libazureinit/src/health.rs
@@ -87,7 +87,6 @@ pub fn encode_report(data: &[String]) -> String {
 }
 
 /// Reports provisioning as successfully completed to the wireserver and/or KVP.
-#[instrument]
 pub async fn report_ready(
     config: &Config,
     vm_id: &str,
@@ -99,7 +98,6 @@ pub async fn report_ready(
 }
 
 /// Reports provisioning failure to the wireserver and/or KVP.
-#[instrument]
 pub async fn report_failure(
     report_str: String,
     config: &Config,
@@ -114,7 +112,6 @@ pub async fn report_failure(
 }
 
 /// Reports provisioning as still in progress to the wireserver and/or KVP.
-#[instrument]
 pub async fn report_in_progress(
     config: &Config,
     vm_id: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,22 +375,7 @@ async fn main() -> ExitCode {
         }
     };
 
-    // Shut down the KVP writer gracefully:
-    // 1. Drop the global subscriber to stop new events from being generated
-    // 2. Wait briefly for any in-flight events to reach the writer
-    // 3. Cancel the graceful_shutdown token to signal the writer to drain and exit
     if let Some(handle) = kvp_completion_rx {
-        // Explicitly drop the global subscriber to ensure no new tracing events
-        // are generated after this point
-        drop(tracing::subscriber::set_default(
-            tracing::subscriber::NoSubscriber::default(),
-        ));
-
-        // Give the tracing pipeline time to deliver any pending events
-        // that were already emitted to the KVP writer before we dropped the subscriber
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-        // Now signal the writer to drain remaining events and shut down
         graceful_shutdown.cancel();
 
         match handle.await {


### PR DESCRIPTION
Despite my earlier PR to enable pre-HTTP telemetry emission, `_report` still fails to emit to .kvp because it closes immediately after the Wireserver connection is established and the root span exits. By creating a custom span for the `_report` function, it ensures that `health::status` events are included, regardless of the main span exiting. 

# Solution
- Ensure the `kvp_writer` has an active span for `_report` to use outside of the `PROVISIONING_REPORT.`
  - Achieved by adding a function-level span on `_report` called `health_status`.
- Added message `"Provisioning report: {}"` to the `health_report` event in `_report()` for visibility in azure-init.log