### PR TITLE
Expose the create-user function to libazureinit

### DIFF
--- a/libazureinit/src/provision/mod.rs
+++ b/libazureinit/src/provision/mod.rs
@@ -53,7 +53,7 @@ impl Provision {
     /// Returns [`Error::NoUserProvisioner`] if no user provisioner backends are
     /// configured or if all backends fail to create the user.
     #[instrument(skip_all)]
-    pub fn create_user(self) -> Result<(), Error> {
+    pub fn create_user(&self) -> Result<(), Error> {
         self.config
             .user_provisioners
             .backends
@@ -87,7 +87,7 @@ impl Provision {
             })
             .ok_or(Error::NoHostnameProvisioner)?;
 
-        self.clone().create_user()?;
+        self.create_user()?;
 
         self.config
             .password_provisioners


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
This PR adds the public `create_user()` function which is now accessible to third party Rust projects for consumption.

## How to use
No usage changes.

## Testing done
This PR has been tested with the testinit process in the CI/CD pipeline.
