### PR TITLE
Add configurable KVP client API and harden concurrent telemetry writes

### DIFF
--- a/doc/libazurekvp.md
+++ b/doc/libazurekvp.md
@@ -80,40 +80,70 @@ For more on how to use these configuration variables, see the [configuration doc
 
 ## Practical Usage
 
-### Instrumenting Functions
+There are two valid ways to emit KVP data:
+- Use the direct `Kvp` client API for explicit event/report writes.
+- Use tracing instrumentation (`#[instrument]` and `event!`) with `setup_layers`.
 
-To instrument code with tracing, use the `#[instrument]` attribute on functions:
+### Using the KVP Client API
+
+For external callers that want to emit KVP diagnostics directly, use the `Kvp` client:
 
 ```rust
-use tracing::{instrument, Level, event};
+use libazureinit::logging::{Kvp, KvpOptions};
+use tracing::Level;
 
-#[instrument(fields(user_id = ?user.id))]
-async fn provision_user(user: User) -> Result<(), Error> {
-    event!(Level::INFO, "Starting user provisioning");
-    
-    // Function logic
-    
-    event!(Level::INFO, "User provisioning completed successfully");
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Simple path: all defaults
+    let kvp = Kvp::new()?;
+    kvp.emit("Provisioning started", None)?; // defaults to DEBUG
+    kvp.emit("Provisioning info event", Some(Level::INFO))?;
+    kvp.emit_health_report("result=success")?;
+    kvp.close().await?;
+
+    // Advanced path: override defaults
+    let custom = Kvp::with_options(
+        KvpOptions::default()
+            .vm_id("00000000-0000-0000-0000-000000000001")
+            .event_prefix("my-service")
+            .file_path("/var/lib/hyperv/.kvp_pool_1")
+            .truncate_on_start(true),
+    )?;
+    custom.emit("Custom event payload", None)?;
+    custom.close().await?;
     Ok(())
 }
 ```
 
-### Emitting Events
+Default behavior for `Kvp::new()`:
+- `vm_id`: resolved from platform metadata (`get_vm_id`)
+- `event_prefix`: `"azure-init-<version>"` (e.g. `"azure-init-0.1.1"`)
+- `file_path`: `/var/lib/hyperv/.kvp_pool_1`
+- `truncate_on_start`: `true`
 
-To record specific points within a span:
+### Truncation and Locking Behavior
+
+On startup, KVP performs a stale-data check and may truncate the guest pool file.
+
+- The truncate path uses file locking to avoid races between clients.
+- If truncation lock acquisition is unavailable (another client already holds it),
+  initialization continues without failing.
+- This lock-contention case is expected in multi-client scenarios and is logged.
+
+### Instrumenting with Tracing
+
+`azure-init` itself continues to use tracing layers (`setup_layers`) for KVP emission.
+To instrument code with tracing, use the `#[instrument]` attribute and `event!`:
 
 ```rust
-use tracing::{event, Level};
+use tracing::{event, instrument, Level};
 
-fn configure_ssh_keys(user: &str, keys: &[String]) {
-    event!(Level::INFO, user = user, key_count = keys.len(), "Configuring SSH keys");
-    
-    for (i, key) in keys.iter().enumerate() {
-        event!(Level::DEBUG, user = user, key_index = i, "Processing SSH key");
-        // Process each key
-    }
-    
-    event!(Level::INFO, user = user, "SSH keys configured successfully");
+#[instrument(fields(user_id = ?user.id))]
+async fn provision_user(user: User) -> Result<(), Error> {
+    event!(Level::INFO, "Starting user provisioning");
+    // Function logic
+    event!(Level::INFO, "User provisioning completed successfully");
+    Ok(())
 }
 ```
 

--- a/libazureinit/src/kvp.rs
+++ b/libazureinit/src/kvp.rs
@@ -45,7 +45,9 @@ use uuid::Uuid;
 const HV_KVP_EXCHANGE_MAX_KEY_SIZE: usize = 512;
 const HV_KVP_EXCHANGE_MAX_VALUE_SIZE: usize = 2048;
 const HV_KVP_AZURE_MAX_VALUE_SIZE: usize = 1022;
-const EVENT_PREFIX: &str = concat!("azure-init-", env!("CARGO_PKG_VERSION"));
+/// The default event prefix used when no custom prefix is provided.
+pub const EVENT_PREFIX: &str =
+    concat!("azure-init-", env!("CARGO_PKG_VERSION"));
 
 /// Encapsulates the KVP (Key-Value Pair) tracing infrastructure.
 ///
@@ -75,6 +77,7 @@ impl Kvp {
     pub(crate) fn new(
         file_path: std::path::PathBuf,
         vm_id: &str,
+        event_prefix: &str,
         graceful_shutdown: CancellationToken,
     ) -> Result<Self, anyhow::Error> {
         truncate_guest_pool_file(&file_path)?;
@@ -96,6 +99,7 @@ impl Kvp {
             tracing_layer: EmitKVPLayer {
                 events_tx,
                 vm_id: vm_id.to_string(),
+                event_prefix: event_prefix.to_string(),
             },
             writer,
         })
@@ -167,7 +171,10 @@ impl Kvp {
     /// # Arguments
     /// * `file` - A mutable reference to the file to write to.
     /// * `kvps` - A slice of encoded KVP messages to write.
-    fn write_kvps(file: &mut File, kvps: &[Vec<u8>]) -> io::Result<()> {
+    pub(crate) fn write_kvps(
+        file: &mut File,
+        kvps: &[Vec<u8>],
+    ) -> io::Result<()> {
         FileExt::lock_exclusive(file).map_err(|e| {
             io::Error::other(format!("Failed to lock KVP file: {e}"))
         })?;
@@ -254,6 +261,7 @@ impl Visit for StringVisitor<'_> {
 pub struct EmitKVPLayer {
     events_tx: UnboundedSender<Vec<u8>>,
     vm_id: String,
+    event_prefix: String,
 }
 
 impl EmitKVPLayer {
@@ -275,8 +283,13 @@ impl EmitKVPLayer {
         span_id: &str,
         event_value: &str,
     ) {
-        let event_key =
-            generate_event_key(&self.vm_id, event_level, event_name, span_id);
+        let event_key = generate_event_key(
+            &self.event_prefix,
+            &self.vm_id,
+            event_level,
+            event_name,
+            span_id,
+        );
         let encoded_kvp = encode_kvp_item(&event_key, event_value);
         let encoded_kvp_flattened: Vec<u8> = encoded_kvp.concat();
         self.send_event(encoded_kvp_flattened);
@@ -425,19 +438,24 @@ where
     }
 }
 
-/// Generates a unique event key by combining the event level, name, and span ID.
+/// Generates a unique event key by combining the event prefix, VM ID, level,
+/// name, and span ID.
 ///
 /// # Arguments
+/// * `event_prefix` - A prefix identifying the emitting application or library
+///   (e.g., `"azure-init-0.1.1"` or `"my-library-2.0"`).
+/// * `vm_id` - The unique identifier for the VM.
 /// * `event_level` - The logging level (e.g., "INFO", "DEBUG").
 /// * `event_name` - The name of the event.
 /// * `span_id` - A unique identifier for the span.
 fn generate_event_key(
+    event_prefix: &str,
     vm_id: &str,
     event_level: &str,
     event_name: &str,
     span_id: &str,
 ) -> String {
-    format!("{EVENT_PREFIX}|{vm_id}|{event_level}|{event_name}|{span_id}")
+    format!("{event_prefix}|{vm_id}|{event_level}|{event_name}|{span_id}")
 }
 
 /// Encodes a key-value pair (KVP) into one or more byte slices. If the value
@@ -452,7 +470,7 @@ fn generate_event_key(
 /// # Arguments
 /// * `key` - The key as a string slice.
 /// * `value` - The value associated with the key.
-fn encode_kvp_item(key: &str, value: &str) -> Vec<Vec<u8>> {
+pub(crate) fn encode_kvp_item(key: &str, value: &str) -> Vec<Vec<u8>> {
     let key_buf = key
         .as_bytes()
         .iter()
@@ -532,37 +550,50 @@ pub fn decode_kvp_item(
 }
 
 /// Truncates the guest pool KVP file if it contains stale data (i.e., data
-/// older than the system's boot time). Logs whether the file was truncated
-/// or no action was needed.
+/// older than the system's boot time).
+///
+/// An exclusive `flock` is held while checking metadata and truncating so
+/// that concurrent processes don't race on the same check-then-truncate
+/// sequence.
 fn truncate_guest_pool_file(kvp_file: &Path) -> Result<(), anyhow::Error> {
     let boot_time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs()
         - get_uptime().as_secs();
 
-    match kvp_file.metadata() {
-        Ok(metadata) => {
-            if metadata.mtime() < boot_time as i64 {
-                OpenOptions::new()
-                    .write(true)
-                    .truncate(true)
-                    .open(kvp_file)?;
-                println!("Truncated the KVP file due to stale data.");
-            } else {
-                println!(
-                    "File has been truncated since boot, no action taken."
-                );
-            }
-        }
+    // Try to open the file; if it doesn't exist there is nothing to truncate.
+    let file = match OpenOptions::new().read(true).write(true).open(kvp_file) {
+        Ok(f) => f,
         Err(ref e) if e.kind() == ErrorKind::NotFound => {
             println!("File not found: {kvp_file:?}");
             return Ok(());
         }
         Err(e) => {
             return Err(anyhow::Error::from(e)
-                .context("Failed to access file metadata"));
+                .context("Failed to open KVP file for truncation"));
         }
-    }
+    };
 
-    Ok(())
+    // Hold an exclusive lock for the metadata-check + truncate window so
+    // that two concurrent callers cannot both decide the file is stale and
+    // truncate data the other has already written.
+    FileExt::lock_exclusive(&file).map_err(|e| {
+        anyhow::Error::from(e).context("Failed to lock KVP file for truncation")
+    })?;
+
+    let result = (|| -> Result<(), anyhow::Error> {
+        let metadata = file.metadata()?;
+        if metadata.mtime() < boot_time as i64 {
+            file.set_len(0)?;
+            println!("Truncated the KVP file due to stale data.");
+        } else {
+            println!("File has been truncated since boot, no action taken.");
+        }
+        Ok(())
+    })();
+
+    // Always release the lock, even if the inner operation failed.
+    let _ = FileExt::unlock(&file);
+
+    result
 }
 
 /// Retrieves the system's uptime using the `sysinfo` crate, returning the duration
@@ -686,9 +717,13 @@ mod tests {
         let test_vm_id = "00000000-0000-0000-0000-000000000001";
 
         let graceful_shutdown = CancellationToken::new();
-        let kvp =
-            Kvp::new(temp_path.clone(), test_vm_id, graceful_shutdown.clone())
-                .expect("Failed to create Kvp");
+        let kvp = Kvp::new(
+            temp_path.clone(),
+            test_vm_id,
+            EVENT_PREFIX,
+            graceful_shutdown.clone(),
+        )
+        .expect("Failed to create Kvp");
 
         let subscriber = Registry::default().with(kvp.tracing_layer);
         let default_guard = tracing::subscriber::set_default(subscriber);
@@ -871,6 +906,7 @@ mod tests {
                 Kvp::new(
                     temp_path.clone(),
                     test_vm_id,
+                    EVENT_PREFIX,
                     graceful_shutdown.clone(),
                 )
                 .expect("Failed to create Kvp")
@@ -898,5 +934,143 @@ mod tests {
         );
 
         println!("KVP file is empty as expected because kvp_diagnostics is disabled.");
+    }
+
+    /// Helper: verify that a file contains exactly `expected` well-formed KVP
+    /// records (each `HV_KVP_EXCHANGE_MAX_KEY_SIZE + HV_KVP_EXCHANGE_MAX_VALUE_SIZE`
+    /// bytes).
+    fn assert_kvp_record_count(path: &std::path::Path, expected: usize) {
+        let contents = std::fs::read(path).expect("Failed to read KVP file");
+        let record_size =
+            HV_KVP_EXCHANGE_MAX_KEY_SIZE + HV_KVP_EXCHANGE_MAX_VALUE_SIZE;
+
+        assert_eq!(
+            contents.len() % record_size,
+            0,
+            "File size ({}) is not a multiple of the record size ({record_size})",
+            contents.len()
+        );
+
+        let actual = contents.len() / record_size;
+        assert_eq!(
+            actual, expected,
+            "Expected {expected} KVP records but found {actual}"
+        );
+
+        // Validate every record is decodable.
+        for i in 0..actual {
+            let start = i * record_size;
+            let end = start + record_size;
+            decode_kvp_item(&contents[start..end])
+                .unwrap_or_else(|e| panic!("Record {i} failed to decode: {e}"));
+        }
+    }
+
+    /// 4 threads × 5,000 iterations writing to the same file via separate FDs.
+    #[test]
+    fn test_multi_thread_kvp_concurrent_writes() {
+        let temp_file =
+            NamedTempFile::new().expect("Failed to create tempfile");
+        let temp_path = temp_file.path().to_path_buf();
+
+        let num_threads: usize = 4;
+        let iterations: usize = 5_000;
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|tid| {
+                let path = temp_path.clone();
+                std::thread::spawn(move || {
+                    // Each thread opens its own file descriptor.
+                    let mut file = OpenOptions::new()
+                        .append(true)
+                        .create(true)
+                        .open(&path)
+                        .expect("Failed to open KVP file");
+
+                    for i in 0..iterations {
+                        let key = format!("thread-{tid}-iter-{i}");
+                        let value = format!("value-{tid}-{i}");
+                        let encoded = encode_kvp_item(&key, &value).concat();
+                        Kvp::write_kvps(&mut file, &[encoded])
+                            .expect("write_kvps failed");
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("Thread panicked");
+        }
+
+        let expected_records = num_threads * iterations;
+        assert_kvp_record_count(&temp_path, expected_records);
+        println!(
+            "Multi-thread test passed: {expected_records} records verified."
+        );
+    }
+
+    /// 4 child processes × 5,000 iterations writing to the same file.
+    ///
+    /// When the env var `__KVP_CHILD_WORKER` is set the process acts as a
+    /// worker (encode + write); otherwise it orchestrates the children.
+    #[test]
+    fn test_multi_process_kvp_concurrent_writes() {
+        let num_processes: usize = 4;
+        let iterations: usize = 5_000;
+
+        // --- Child worker path ---
+        if let Ok(path) = std::env::var("__KVP_CHILD_WORKER_PATH") {
+            let pid = std::process::id();
+            let mut file = OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&path)
+                .expect("Child: failed to open KVP file");
+
+            for i in 0..iterations {
+                let key = format!("proc-{pid}-iter-{i}");
+                let value = format!("value-{pid}-{i}");
+                let encoded = encode_kvp_item(&key, &value).concat();
+                Kvp::write_kvps(&mut file, &[encoded])
+                    .expect("Child: write_kvps failed");
+            }
+            return; // done – the parent will verify the file.
+        }
+
+        // --- Parent orchestrator path ---
+        let temp_file =
+            NamedTempFile::new().expect("Failed to create tempfile");
+        let temp_path = temp_file.path().to_path_buf();
+
+        let test_exe = std::env::current_exe()
+            .expect("Failed to determine test executable path");
+
+        let children: Vec<_> = (0..num_processes)
+            .map(|_| {
+                std::process::Command::new(&test_exe)
+                    .env("__KVP_CHILD_WORKER_PATH", temp_path.to_str().unwrap())
+                    .arg("--exact")
+                    .arg("kvp::tests::test_multi_process_kvp_concurrent_writes")
+                    .arg("--nocapture")
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+                    .spawn()
+                    .expect("Failed to spawn child process")
+            })
+            .collect();
+
+        for mut child in children {
+            let status = child.wait().expect("Failed to wait on child");
+            assert!(
+                status.success(),
+                "Child process exited with failure: {status}"
+            );
+        }
+
+        let expected_records = num_processes * iterations;
+        assert_kvp_record_count(&temp_path, expected_records);
+        println!(
+            "Multi-process test passed: {expected_records} records verified."
+        );
     }
 }

--- a/libazureinit/src/kvp.rs
+++ b/libazureinit/src/kvp.rs
@@ -15,7 +15,7 @@ use std::{
     fs::{File, OpenOptions},
     io::{self, ErrorKind, Write},
     os::unix::fs::MetadataExt,
-    path::Path,
+    path::{Path, PathBuf},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -23,8 +23,9 @@ use fs2::FileExt;
 
 use tracing::{
     field::Visit,
+    info,
     span::{Attributes, Id},
-    Subscriber,
+    warn, Level, Subscriber,
 };
 
 use tracing_subscriber::{
@@ -48,6 +49,49 @@ const HV_KVP_AZURE_MAX_VALUE_SIZE: usize = 1022;
 /// The default event prefix used when no custom prefix is provided.
 pub const EVENT_PREFIX: &str =
     concat!("azure-init-", env!("CARGO_PKG_VERSION"));
+const DEFAULT_KVP_FILE_PATH: &str = "/var/lib/hyperv/.kvp_pool_1";
+
+/// Configuration options for creating a [`Kvp`] client.
+#[derive(Clone, Debug)]
+pub struct KvpOptions {
+    pub vm_id: Option<String>,
+    pub event_prefix: Option<String>,
+    pub file_path: PathBuf,
+    pub truncate_on_start: bool,
+}
+
+impl Default for KvpOptions {
+    fn default() -> Self {
+        Self {
+            vm_id: None,
+            event_prefix: None,
+            file_path: PathBuf::from(DEFAULT_KVP_FILE_PATH),
+            truncate_on_start: true,
+        }
+    }
+}
+
+impl KvpOptions {
+    pub fn vm_id<T: Into<String>>(mut self, vm_id: T) -> Self {
+        self.vm_id = Some(vm_id.into());
+        self
+    }
+
+    pub fn event_prefix<T: Into<String>>(mut self, event_prefix: T) -> Self {
+        self.event_prefix = Some(event_prefix.into());
+        self
+    }
+
+    pub fn file_path<T: AsRef<Path>>(mut self, file_path: T) -> Self {
+        self.file_path = file_path.as_ref().to_path_buf();
+        self
+    }
+
+    pub fn truncate_on_start(mut self, truncate_on_start: bool) -> Self {
+        self.truncate_on_start = truncate_on_start;
+        self
+    }
+}
 
 /// Encapsulates the KVP (Key-Value Pair) tracing infrastructure.
 ///
@@ -63,9 +107,37 @@ pub struct Kvp {
     /// KVP data to the file. The caller can use this handle to wait for
     /// the writer to finish.
     pub(crate) writer: JoinHandle<io::Result<()>>,
+    shutdown: Option<CancellationToken>,
 }
 
 impl Kvp {
+    /// Create a new KVP client with sensible defaults.
+    pub fn new() -> Result<Self, anyhow::Error> {
+        Self::with_options(KvpOptions::default())
+    }
+
+    /// Create a new KVP client with explicit options.
+    pub fn with_options(options: KvpOptions) -> Result<Self, anyhow::Error> {
+        let vm_id = match options.vm_id {
+            Some(vm_id) => vm_id,
+            None => crate::get_vm_id()
+                .ok_or_else(|| anyhow::anyhow!("Failed to resolve VM ID"))?,
+        };
+        let event_prefix = options
+            .event_prefix
+            .unwrap_or_else(|| EVENT_PREFIX.to_string());
+        let shutdown = CancellationToken::new();
+        let mut kvp = Self::new_internal(
+            options.file_path,
+            &vm_id,
+            &event_prefix,
+            shutdown.clone(),
+            options.truncate_on_start,
+        )?;
+        kvp.shutdown = Some(shutdown);
+        Ok(kvp)
+    }
+
     /// Opens a KVP guest pool file for appending.
     ///
     /// All callers that need a file handle for KVP writes should go through
@@ -82,13 +154,16 @@ impl Kvp {
     /// - It creates an unbounded channel for passing encoded KVP data from the
     ///   tracing layer to the writer task.
     /// - It spawns the `kvp_writer` task, which listens for data and shutdown signals.
-    pub(crate) fn new(
+    pub(crate) fn new_internal(
         file_path: std::path::PathBuf,
         vm_id: &str,
         event_prefix: &str,
         graceful_shutdown: CancellationToken,
+        truncate_on_start: bool,
     ) -> Result<Self, anyhow::Error> {
-        truncate_guest_pool_file(&file_path)?;
+        if truncate_on_start {
+            truncate_guest_pool_file(&file_path)?;
+        }
 
         let file = Self::open_kvp_file(&file_path)?;
 
@@ -107,7 +182,42 @@ impl Kvp {
                 event_prefix: event_prefix.to_string(),
             },
             writer,
+            shutdown: None,
         })
+    }
+
+    /// Emit a KVP event. Defaults to `DEBUG` level if none provided.
+    pub fn emit(
+        &self,
+        message: &str,
+        level: Option<Level>,
+    ) -> Result<(), anyhow::Error> {
+        let level = level.unwrap_or(Level::DEBUG);
+        self.tracing_layer.handle_kvp_operation(
+            level.as_str(),
+            "kvp_emit",
+            &Uuid::new_v4().to_string(),
+            message,
+        );
+        Ok(())
+    }
+
+    /// Emit a provisioning report (`PROVISIONING_REPORT`) entry.
+    pub fn emit_health_report<T: AsRef<str>>(
+        &self,
+        report: T,
+    ) -> Result<(), anyhow::Error> {
+        self.tracing_layer.emit_health_report(report.as_ref());
+        Ok(())
+    }
+
+    /// Gracefully stop the writer and flush queued KVP data.
+    pub async fn close(self) -> Result<(), anyhow::Error> {
+        if let Some(shutdown) = self.shutdown {
+            shutdown.cancel();
+        }
+        self.writer.await??;
+        Ok(())
     }
 
     /// The background task that writes encoded KVP data to a file.
@@ -298,6 +408,12 @@ impl EmitKVPLayer {
         let encoded_kvp = encode_kvp_item(&event_key, event_value);
         let encoded_kvp_flattened: Vec<u8> = encoded_kvp.concat();
         self.send_event(encoded_kvp_flattened);
+    }
+
+    /// Sends a provisioning report directly into the writer queue.
+    pub(crate) fn emit_health_report(&self, report: &str) {
+        let msg = encode_kvp_item("PROVISIONING_REPORT", report).concat();
+        self.send_event(msg);
     }
 }
 
@@ -580,9 +696,13 @@ fn truncate_guest_pool_file(kvp_file: &Path) -> Result<(), anyhow::Error> {
     // Hold an exclusive lock for the metadata-check + truncate window so
     // that two concurrent callers cannot both decide the file is stale and
     // truncate data the other has already written.
-    FileExt::lock_exclusive(&file).map_err(|e| {
-        anyhow::Error::from(e).context("Failed to lock KVP file for truncation")
-    })?;
+    if let Err(e) = FileExt::try_lock_exclusive(&file) {
+        warn!(
+            "Could not acquire KVP truncation lock; assuming another client is handling truncation: {}",
+            e
+        );
+        return Ok(());
+    }
 
     let result = (|| -> Result<(), anyhow::Error> {
         let metadata = file.metadata()?;
@@ -591,6 +711,7 @@ fn truncate_guest_pool_file(kvp_file: &Path) -> Result<(), anyhow::Error> {
             println!("Truncated the KVP file due to stale data.");
         } else {
             println!("File has been truncated since boot, no action taken.");
+            info!("KVP file already fresh since boot; no truncation needed.");
         }
         Ok(())
     })();
@@ -722,11 +843,12 @@ mod tests {
         let test_vm_id = "00000000-0000-0000-0000-000000000001";
 
         let graceful_shutdown = CancellationToken::new();
-        let kvp = Kvp::new(
+        let kvp = Kvp::new_internal(
             temp_path.clone(),
             test_vm_id,
             EVENT_PREFIX,
             graceful_shutdown.clone(),
+            true,
         )
         .expect("Failed to create Kvp");
 
@@ -846,6 +968,81 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_truncate_lock_contention_is_non_fatal() {
+        const LOCK_ENV_PATH: &str = "__KVP_TRUNCATION_LOCK_PATH";
+
+        // Child path: hold an exclusive lock briefly, then exit.
+        if let Ok(path) = std::env::var(LOCK_ENV_PATH) {
+            let lock_file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+                .expect("Child: open lock file");
+            FileExt::lock_exclusive(&lock_file).expect("Child: acquire lock");
+            std::thread::sleep(std::time::Duration::from_millis(800));
+            return;
+        }
+
+        let temp_file =
+            NamedTempFile::new().expect("Failed to create tempfile");
+        let temp_path = temp_file.path().to_path_buf();
+        std::fs::write(&temp_path, "stale-ish data")
+            .expect("Failed to seed temp file");
+
+        let test_exe = std::env::current_exe()
+            .expect("Failed to determine test executable path");
+
+        let mut child = std::process::Command::new(&test_exe)
+            .env(LOCK_ENV_PATH, temp_path.to_str().unwrap())
+            .arg("--exact")
+            .arg("kvp::tests::test_truncate_lock_contention_is_non_fatal")
+            .arg("--nocapture")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn child lock holder");
+
+        // Give the child a moment to acquire the lock.
+        std::thread::sleep(std::time::Duration::from_millis(150));
+
+        let graceful_shutdown = CancellationToken::new();
+        let start = std::time::Instant::now();
+        let kvp = Kvp::new_internal(
+            temp_path.clone(),
+            "00000000-0000-0000-0000-000000000003",
+            EVENT_PREFIX,
+            graceful_shutdown.clone(),
+            true,
+        );
+        let elapsed = start.elapsed();
+
+        assert!(
+            kvp.is_ok(),
+            "Kvp initialization should not fail under truncation lock contention"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "Kvp initialization should return quickly under lock contention, took {:?}",
+            elapsed
+        );
+
+        graceful_shutdown.cancel();
+        kvp.expect("Kvp should initialize")
+            .writer
+            .await
+            .expect("KVP writer task panicked")
+            .expect("KVP writer task returned an IO error");
+
+        let status = child.wait().expect("Failed to wait on child");
+        assert!(
+            status.success(),
+            "Child lock holder exited with failure: {status}"
+        );
+    }
+
     #[test]
     fn test_encode_kvp_item_value_length() {
         let key = "test_key";
@@ -908,11 +1105,12 @@ mod tests {
         let graceful_shutdown = CancellationToken::new();
         let emit_kvp_layer = if kvp_enabled {
             Some(
-                Kvp::new(
+                Kvp::new_internal(
                     temp_path.clone(),
                     test_vm_id,
                     EVENT_PREFIX,
                     graceful_shutdown.clone(),
+                    true,
                 )
                 .expect("Failed to create Kvp")
                 .tracing_layer,

--- a/libazureinit/src/logging.rs
+++ b/libazureinit/src/logging.rs
@@ -11,13 +11,12 @@ use tracing::{event, Level, Subscriber};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{
-    filter::Filtered, fmt, layer::SubscriberExt, registry::LookupSpan,
-    EnvFilter, Layer, Registry,
+    fmt, layer::SubscriberExt, EnvFilter, Layer, Registry,
 };
 
 use crate::config::Config;
-pub use crate::kvp::EVENT_PREFIX;
-use crate::kvp::{EmitKVPLayer, Kvp as KvpInternal};
+pub use crate::kvp::{Kvp, KvpOptions};
+use crate::kvp::{Kvp as KvpInternal, EVENT_PREFIX};
 
 pub type LoggingSetup = (
     Box<dyn Subscriber + Send + Sync + 'static>,
@@ -122,107 +121,6 @@ fn get_kvp_filter(
     }
 }
 
-// Public KVP wrapper API for library consumers
-struct KvpLayer<S: Subscriber>(Filtered<EmitKVPLayer, EnvFilter, S>);
-
-/// Emit tracing data to the Hyper-V KVP.
-///
-/// ## KVP Tracing Configuration
-///
-/// The KVP tracing layer's filter can be configured at runtime by setting the
-/// `AZURE_INIT_KVP_FILTER` environment variable. This allows any application
-/// using this library to override the default filter and control which traces
-/// are sent to the KVP pool.
-///
-/// The value of the variable must be a string that follows the syntax for
-/// `tracing_subscriber::EnvFilter`, which is a comma-separated list of
-/// logging directives. For example: `warn,my_crate=debug` or `info,my_crate::api=trace`.
-/// See `config.rs` for more details.
-///
-/// The filter can also be configured via the `kvp_filter` field in the `Config` struct.
-/// **Precedence**: Environment variable > Config field > Default filter.
-/// If neither is set, a default filter tailored for `azure-init` (WARN level + specific modules) is used.
-///
-/// If an invalid filter string is provided (via env or config), a warning is logged
-/// and the default filter is used instead.
-///
-/// # Example
-///
-/// ```no_run
-/// # use libazureinit::logging::Kvp;
-/// use tracing_subscriber::layer::SubscriberExt;
-///
-/// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
-/// let mut kvp = Kvp::new("a-unique-id", None)?;
-/// let registry = tracing_subscriber::Registry::default().with(kvp.layer());
-///
-/// // When it's time to shut down, doing this ensures all writes are flushed
-/// kvp.halt().await?;
-/// # Ok(())
-/// # }
-/// ```
-pub struct Kvp<S: Subscriber> {
-    layer: Option<KvpLayer<S>>,
-    /// The `JoinHandle` for the background task responsible for writing
-    /// KVP data to the file. The caller can use this handle to wait for
-    /// the writer to finish.
-    writer: JoinHandle<std::io::Result<()>>,
-    shutdown: CancellationToken,
-}
-
-impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Kvp<S> {
-    /// Create a new tracing layer for KVP.
-    ///
-    /// When `event_prefix` is `None`, the default [`EVENT_PREFIX`] is used.
-    /// Pass `Some("my-library-1.0")` to identify a different emitting library.
-    ///
-    /// Refer to [`libazureinit::get_vm_id`] to retrieve the VM's unique identifier.
-    pub fn new<T: AsRef<str>>(
-        vm_id: T,
-        event_prefix: Option<&str>,
-    ) -> Result<Self, anyhow::Error> {
-        let event_prefix = event_prefix.unwrap_or(EVENT_PREFIX);
-        let shutdown = CancellationToken::new();
-        let inner = KvpInternal::new(
-            std::path::PathBuf::from("/var/lib/hyperv/.kvp_pool_1"),
-            vm_id.as_ref(),
-            event_prefix,
-            shutdown.clone(),
-        )?;
-
-        let kvp_filter = get_kvp_filter(None)?;
-        let layer = Some(KvpLayer(inner.tracing_layer.with_filter(kvp_filter)));
-
-        Ok(Self {
-            layer,
-            writer: inner.writer,
-            shutdown,
-        })
-    }
-
-    /// Get a tracing [`Layer`] to use with a [`Registry`].
-    ///
-    /// # Panics if this function is called more than once.
-    pub fn layer(&mut self) -> Filtered<EmitKVPLayer, EnvFilter, S> {
-        assert!(
-            self.layer.is_some(),
-            "Kvp::layer cannot be called multiple times!"
-        );
-        self.layer.take().unwrap().0
-    }
-
-    /// Gracefully shut down the KVP writer.
-    ///
-    /// This will stop new KVP logs from being queued and wait for all pending writes to the KVP
-    /// pool to complete.  After this returns, no further logs will be written to KVP.
-    pub async fn halt(self) -> Result<(), anyhow::Error> {
-        self.shutdown.cancel();
-        self.writer.await??;
-        Ok(())
-    }
-}
-
 /// Builds a `tracing` subscriber that can optionally write azure-init.log
 /// to a specific location if `Some(&Config)` is provided.
 ///
@@ -250,11 +148,14 @@ pub fn setup_layers(
         .telemetry
         .kvp_diagnostics
     {
-        match KvpInternal::new(
-            std::path::PathBuf::from("/var/lib/hyperv/.kvp_pool_1"),
+        // Preserve existing azure-init behavior for subscriber wiring.
+        let options = KvpOptions::default();
+        match KvpInternal::new_internal(
+            options.file_path,
             vm_id,
             EVENT_PREFIX,
             graceful_shutdown,
+            options.truncate_on_start,
         ) {
             Ok(kvp) => {
                 let layer = kvp.tracing_layer.with_filter(kvp_filter);
@@ -642,5 +543,30 @@ mod tests {
         assert!(!stderr_contents.contains("This is an info message"));
         assert!(!stderr_contents.contains("This is a warn message"));
         assert!(stderr_contents.contains("This is an error message"));
+    }
+
+    #[tokio::test]
+    async fn test_kvp_client_emit_and_close_writes_data() {
+        let temp_file =
+            NamedTempFile::new().expect("Failed to create tempfile");
+        let temp_path = temp_file.path().to_path_buf();
+
+        let options = KvpOptions::default()
+            .vm_id("00000000-0000-0000-0000-000000000099")
+            .event_prefix("kvp-client-test")
+            .file_path(&temp_path);
+
+        let kvp = Kvp::with_options(options).expect("create kvp client");
+        kvp.emit("hello-world", None).expect("emit event");
+        kvp.emit_health_report("result=success")
+            .expect("emit report");
+        kvp.close().await.expect("close kvp client");
+
+        let bytes = std::fs::read(&temp_path).expect("read kvp file");
+        assert!(!bytes.is_empty(), "Expected KVP file to contain data");
+
+        let contents = String::from_utf8_lossy(&bytes);
+        assert!(contents.contains("hello-world"));
+        assert!(contents.contains("PROVISIONING_REPORT"));
     }
 }


### PR DESCRIPTION
## Summary
Expands KVP telemetry beyond the original event-prefix change by introducing a public, external-caller-friendly KVP client API, while strengthening concurrency behavior for startup truncation and documenting the end-to-end design.

This enables multiple emitters/libraries to coexist more safely and gives callers explicit control over KVP emission lifecycle and identity.

## Changes

### New public KVP client API (`kvp.rs`, re-exported via `logging.rs`)
- Added `KvpOptions` with builder-style configuration:
  - `vm_id`
  - `event_prefix`
  - `file_path`
  - `truncate_on_start`
- Added `Kvp::new()` (default options path).
- Added `Kvp::with_options(...)` for explicit caller configuration.
- Added direct emission APIs:
  - `emit(message, level)`
  - `emit_health_report(report)`
- Added `close().await` for graceful shutdown and queue drain.

### Internal wiring updates (`logging.rs`)
- `setup_layers` continues to use tracing-layer emission internally.
- Internal construction now goes through `Kvp::new_internal(...)` with explicit options-derived inputs.
- Existing azure-init tracing behavior remains intact.

### Concurrency hardening for startup truncation (`kvp.rs`)
- Truncation path now uses file locking to avoid check-then-truncate races.
- Lock contention during truncation is treated as non-fatal (expected in multi-client environments), allowing initialization to continue safely.

## Breaking Changes
This PR intentionally changes the public KVP API shape:
- Removed old subscriber-wrapper usage pattern (`Kvp<S>::new(...), .layer(), .halt()`).
- Replaced with direct client API (`Kvp::new/with_options`, `emit`, `emit_health_report`, `close`).

## Goal
- Make KVP emission straightforward for external callers without requiring `tracing_subscriber` plumbing.
- Support concurrent/multi-emitter scenarios more safely.
- Keep internal azure-init tracing integration while exposing a cleaner public surface.

Resolves #239
