### PR TITLE
Add Ubuntu 26.04 to e2e testing

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          - ubuntu:26.04
           - ubuntu:24.04
           - debian:13
           - mcr.microsoft.com/azurelinux/base/core:3.0


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
Adds Ubuntu 26.04 to the E2E pipeline now that the Docker image is generally available.

## How to use
N/A - Run automatically on PRs via the pipeline.
<!-- [ Describe what reviewers need to do in order to validate this PR ] -->
