### PR TITLE
feat(ci): per-file code coverage reporting

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -50,6 +50,46 @@ jobs:
         if: always()
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Generate per-file coverage table
+        if: always()
+        run: |
+          python3 - <<'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+
+          tree = ET.parse("cobertura.xml")
+          root = tree.getroot()
+
+          files = []
+          for cls in root.iter("class"):
+              filename = cls.get("filename", "")
+              lines = cls.findall(".//line")
+              total = len(lines)
+              if total == 0:
+                  continue
+              covered = sum(1 for l in lines if int(l.get("hits", 0)) > 0)
+              line_rate = covered / total * 100
+              branch_rate = float(cls.get("branch-rate", 0)) * 100
+              files.append((filename, line_rate, branch_rate, covered, total))
+
+          files.sort(key=lambda f: f[0])
+
+          def indicator(pct):
+              if pct >= 100:
+                  return "✔"
+              elif pct >= 95:
+                  return "-"
+              else:
+                  return "❌"
+
+          print("\n## Per-File Coverage\n")
+          print("| File | Line Coverage | Branch Coverage | Lines Covered / Total |")
+          print("|------|-------------:|----------------:|----------------------:|")
+          for name, line_pct, branch_pct, covered, total in files:
+              li = indicator(line_pct)
+              bi = indicator(branch_pct)
+              print(f"| `{name}` | {li} {line_pct:.1f}% | {bi} {branch_pct:.1f}% | {covered}/{total} |")
+          PYEOF
+
       - name: Install diff-cover
         run: pip install diff-cover
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -75,8 +75,6 @@ jobs:
           def indicator(pct):
               if pct >= 100:
                   return "✔"
-              elif pct >= 95:
-                  return "-"
               else:
                   return "❌"
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -68,8 +68,7 @@ jobs:
                   continue
               covered = sum(1 for l in lines if int(l.get("hits", 0)) > 0)
               line_rate = covered / total * 100
-              branch_rate = float(cls.get("branch-rate", 0)) * 100
-              files.append((filename, line_rate, branch_rate, covered, total))
+              files.append((filename, line_rate, covered, total))
 
           files.sort(key=lambda f: f[0])
 
@@ -82,12 +81,11 @@ jobs:
                   return "❌"
 
           print("\n## Per-File Coverage\n")
-          print("| File | Line Coverage | Branch Coverage | Lines Covered / Total |")
-          print("|------|-------------:|----------------:|----------------------:|")
-          for name, line_pct, branch_pct, covered, total in files:
+          print("| File | Line Coverage | Lines Covered / Total |")
+          print("|------|-------------:|----------------------:|")
+          for name, line_pct, covered, total in files:
               li = indicator(line_pct)
-              bi = indicator(branch_pct)
-              print(f"| `{name}` | {li} {line_pct:.1f}% | {bi} {branch_pct:.1f}% | {covered}/{total} |")
+              print(f"| `{name}` | {li} {line_pct:.1f}% | {covered}/{total} |")
           PYEOF
 
       - name: Install diff-cover


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
Adds a Python script to enable per-file code coverage reporting. `cargo llvm-cov` does not offer great ways to show the coverage by file, but the cobertura.xml file that is produced for the `irongut` coverage report can be easily parsed to view this information. 

This brings us to a similar spot as PRs in ADO. Per-file and per-line reporting is now right in the same location.

## How to use
Completed automatically via the E2E pipeline. Click the `Details` on the `Code Coverage Report` pipeline, then `Summary` in the top left.
<!-- [ Describe what reviewers need to do in order to validate this PR ] -->
