### PR TITLE
fix(ci): run code coverage on main

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,6 +1,9 @@
 name: "Code Coverage Report"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
When the codecov pipeline is not run on the main branch, we run into an issue showing `missing BASE report` ([more info here](https://docs.codecov.com/docs/error-reference#missing-base-report) and [see it in practice here](https://github.com/Azure/azure-init/pull/295#issuecomment-4291450470)). This enables the reporting for the base branch.