### PR TITLE
fix(ci): add a timeout to stop failed containers

### DIFF
--- a/testinit/start-all.sh
+++ b/testinit/start-all.sh
@@ -22,7 +22,7 @@ while true; do
   # Check journal logs for either a success or a failure to ensure the completion of the service
   if docker exec azureinit-provisioning-agent journalctl -u azure-init.service --no-pager | grep -q "Finished azure-init.service"; then
     echo "azure-init.service has finished"
-    # break
+    break
   fi
   if  docker exec azureinit-provisioning-agent journalctl -u azure-init.service --no-pager | grep -i 'azure-init' | grep -Eiq 'failed|failure'; then
     echo "azure-init.service has failed."

--- a/testinit/start-all.sh
+++ b/testinit/start-all.sh
@@ -22,7 +22,7 @@ while true; do
   # Check journal logs for either a success or a failure to ensure the completion of the service
   if docker exec azureinit-provisioning-agent journalctl -u azure-init.service --no-pager | grep -q "Finished azure-init.service"; then
     echo "azure-init.service has finished"
-    break
+    # break
   fi
   if  docker exec azureinit-provisioning-agent journalctl -u azure-init.service --no-pager | grep -i 'azure-init' | grep -Eiq 'failed|failure'; then
     echo "azure-init.service has failed."

--- a/testinit/start-all.sh
+++ b/testinit/start-all.sh
@@ -15,6 +15,9 @@ popd
 echo "Starting azureinit-provisioning-agent (connects to existing networks)..."
 BASE_IMAGE=$BASE_IMAGE docker compose up -d --build
 
+TIMEOUT=1200  # 20 minutes in seconds
+ELAPSED=0
+
 while true; do
   # Check journal logs for either a success or a failure to ensure the completion of the service
   if docker exec azureinit-provisioning-agent journalctl -u azure-init.service --no-pager | grep -q "Finished azure-init.service"; then
@@ -25,8 +28,13 @@ while true; do
     echo "azure-init.service has failed."
     break
   fi
-  echo "Waiting for azure-init.service to finish..."
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "ERROR: Timed out after 20 minutes waiting for azure-init.service to complete."
+    exit 1
+  fi
+  echo "Waiting for azure-init.service to finish... (${ELAPSED}s/${TIMEOUT}s)"
   sleep 10
+  ELAPSED=$((ELAPSED + 10))
 done
 
 echo "Testing-server is available at the Azure service endpoints:"


### PR DESCRIPTION
<!-- [ Describe the change in 1 - 3 paragraphs ] -->
Adds a timeout to stop containers that have failed to build correctly, but have not thrown the expected errors.

## Testing done
Forced a timeout in commit 5ac1145 to show the correct behavior taking place. Reverted this commit after proof.
<!-- [ Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got so maintainers can re-test if necessary ] -->
